### PR TITLE
Feat/#7 youthcenter open api

### DIFF
--- a/src/main/java/com/youthjob/api/youthpolicy/client/RestClientConfig.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/client/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.youthjob.api.youthpolicy.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+    @Bean
+    RestClient youthPolicyRestClient(@Value("${api.youthpolicy.base-url}") String baseUrl) {
+        return RestClient.builder().baseUrl(baseUrl).build();
+    }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/client/YouthPolicyClient.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/client/YouthPolicyClient.java
@@ -1,0 +1,67 @@
+package com.youthjob.api.youthpolicy.client;
+
+import com.youthjob.api.youthpolicy.dto.YouthPolicyApiRequestDto;
+import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class YouthPolicyClient {
+
+    private final RestClient youthPolicyRestClient;
+
+    @Value("${api.youthpolicy.key}")
+    private String apiKey;
+
+    @Value("${api.youthpolicy.path:/go/ythip/getPlcy}")
+    private String path;
+
+    public YouthPolicyApiResponseDto search(YouthPolicyApiRequestDto req) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        // 필수 파라미터
+        params.add("apiKeyNm", apiKey);
+        params.add("rtnType",  req.getRtnType());
+        params.add("pageNum",  String.valueOf(req.getPageNum()));
+        params.add("pageSize", String.valueOf(req.getPageSize()));
+        params.add("pageType", String.valueOf(req.getPageType()));
+        // 선택 파라미터
+        add(params, "plcyNo",      req.getPlcyNo());
+        add(params, "plcyKywdNm",  req.getPlcyKywdNm());
+        add(params, "plcyExpInCn", req.getPlcyExpInCn());
+        add(params, "plcyNm",      req.getPlcyNm());
+        add(params, "zipCd",       req.getZipCd());
+        add(params, "lclsfNm",     req.getLclsfNm());
+        add(params, "mclsfNm",     req.getMclsfNm());
+
+        return youthPolicyRestClient.get()
+                .uri(uri -> uri.path(path).queryParams(params).build())
+                .retrieve()
+                .body(YouthPolicyApiResponseDto.class);
+    }
+
+    // 스냅샷이 없는 경우 외부 api를 직접 호출하는 방식 -> 호출 후 저장함
+    public YouthPolicyApiResponseDto findByPlcyNo(String plcyNo) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("apiKeyNm", apiKey);
+        params.add("rtnType", "json");
+        params.add("pageNum", "1");
+        params.add("pageSize", "1");
+        params.add("pageType", "2");      // 상세
+        params.add("plcyNo", plcyNo);
+
+        return youthPolicyRestClient.get()
+                .uri(u -> u.path(path).queryParams(params).build())
+                .retrieve()
+                .body(YouthPolicyApiResponseDto.class);
+    }
+
+
+    private static void add(MultiValueMap<String, String> map, String k, String v) {
+        if (v != null && !v.isBlank()) map.add(k, v);
+    }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyController.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyController.java
@@ -1,26 +1,28 @@
 package com.youthjob.api.youthpolicy.controller;
 
-import com.youthjob.api.youthpolicy.client.YouthPolicyClient;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyApiRequestDto;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyDetailDto;
+import com.youthjob.api.youthpolicy.service.YouthPolicyService;
+import com.youthjob.api.youthpolicy.client.YouthPolicyClient;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
+        import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/youth-policies")
 public class YouthPolicyController {
 
+    private final YouthPolicyService service;
     private final YouthPolicyClient client;
 
-    /** api 검색, 호출 예: /api/v1/youth-policies?plcyKywdNm=보조금&pageNum=1&pageSize=10 */
+    /** 검색 + 후처리 필터 호출 예: /api/v1/youth-policies?plcyKywdNm=보조금&pageNum=1&pageSize=10 */
     @GetMapping
     public YouthPolicyApiResponseDto list(@Valid @ModelAttribute YouthPolicyApiRequestDto req) {
-        return client.search(req);
+        return service.searchWithFilter(req);
     }
 
     /** 각 정책별 상세정보: /api/v1/youth-policies/{plcyNo} */
@@ -35,7 +37,6 @@ public class YouthPolicyController {
 
         var p = resp.getResult().getYouthPolicyList().get(0);
 
-        // 뷰 DTO로 요약 반환 (프론트 필요한 정보 보고 수정할 예정)
         return YouthPolicyDetailDto.builder()
                 .plcyNo(p.getPlcyNo())
                 .plcyNm(p.getPlcyNm())

--- a/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyController.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyController.java
@@ -1,0 +1,52 @@
+package com.youthjob.api.youthpolicy.controller;
+
+import com.youthjob.api.youthpolicy.client.YouthPolicyClient;
+import com.youthjob.api.youthpolicy.dto.YouthPolicyApiRequestDto;
+import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto;
+import com.youthjob.api.youthpolicy.dto.YouthPolicyDetailDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/youth-policies")
+public class YouthPolicyController {
+
+    private final YouthPolicyClient client;
+
+    /** api 검색, 호출 예: /api/v1/youth-policies?plcyKywdNm=보조금&pageNum=1&pageSize=10 */
+    @GetMapping
+    public YouthPolicyApiResponseDto list(@Valid @ModelAttribute YouthPolicyApiRequestDto req) {
+        return client.search(req);
+    }
+
+    /** 각 정책별 상세정보: /api/v1/youth-policies/{plcyNo} */
+    @GetMapping("/{plcyNo}")
+    public YouthPolicyDetailDto detail(@PathVariable String plcyNo) {
+        var resp = client.findByPlcyNo(plcyNo);
+        if (resp == null || resp.getResult() == null ||
+                resp.getResult().getYouthPolicyList() == null ||
+                resp.getResult().getYouthPolicyList().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "정책을 찾을 수 없습니다: " + plcyNo);
+        }
+
+        var p = resp.getResult().getYouthPolicyList().get(0);
+
+        // 뷰 DTO로 요약 반환 (프론트 필요한 정보 보고 수정할 예정)
+        return YouthPolicyDetailDto.builder()
+                .plcyNo(p.getPlcyNo())
+                .plcyNm(p.getPlcyNm())
+                .plcyKywdNm(p.getPlcyKywdNm())
+                .plcyExplnCn(p.getPlcyExplnCn())
+                .lclsfNm(p.getLclsfNm())
+                .mclsfNm(p.getMclsfNm())
+                .aplyYmd(p.getAplyYmd())
+                .aplyUrlAddr(p.getAplyUrlAddr())
+                .sprvsnInstCdNm(p.getSprvsnInstCdNm())
+                .operInstCdNm(p.getOperInstCdNm())
+                .build();
+    }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyFavoriteController.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyFavoriteController.java
@@ -1,0 +1,44 @@
+package com.youthjob.api.youthpolicy.controller;
+
+import com.youthjob.api.youthpolicy.dto.SavePolicyRequest;
+import com.youthjob.api.youthpolicy.dto.SavedPolicyDto;
+import com.youthjob.api.youthpolicy.service.YouthPolicyFavoriteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/youth-policies")
+public class YouthPolicyFavoriteController {
+
+    private final YouthPolicyFavoriteService service;
+
+    /** 내 관심 정책 목록 */
+    @GetMapping("/saved")
+    public ResponseEntity<List<SavedPolicyDto>> listSaved() {
+        return ResponseEntity.ok(service.listSaved());
+    }
+
+    /** 관심 저장 (스냅샷 없으면 서버가 외부 API로 채움) */
+    @PostMapping("/saved")
+    public ResponseEntity<SavedPolicyDto> save(@RequestBody @Valid SavePolicyRequest req) {
+        return ResponseEntity.ok(service.save(req));
+    }
+
+    /** 관심 삭제 */
+    @DeleteMapping("/saved/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /** 토글: 있으면 삭제(null 반환), 없으면 저장(저장 DTO 반환) */
+    @PostMapping("/saved/toggle")
+    public ResponseEntity<SavedPolicyDto> toggle(@RequestBody @Valid SavePolicyRequest req) {
+        return ResponseEntity.ok(service.toggle(req));
+    }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/domain/SavedPolicy.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/domain/SavedPolicy.java
@@ -1,0 +1,61 @@
+package com.youthjob.api.youthpolicy.domain;
+
+import com.youthjob.api.auth.domain.User;
+import com.youthjob.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    name = "saved_policy",
+    uniqueConstraints = @UniqueConstraint(name = "uk_saved_policy_user_plcyno", columnNames = {"user_id","plcy_no"}),
+    indexes = {
+        @Index(name = "idx_saved_policy_user", columnList = "user_id"),
+        @Index(name = "idx_saved_policy_plcyno", columnList = "plcy_no")
+    }
+)
+public class SavedPolicy extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 저장한 사용자 */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_saved_policy_user"))
+    private User user;
+
+    /** 청년정책 식별자 */
+    @Column(name = "plcy_no", nullable = false, length = 30)
+    private String plcyNo;
+
+    // ===== 스냅샷 =====
+    @Column(length = 300) private String plcyNm;        // 정책명
+    @Column(length = 200) private String plcyKywdNm;    // 키워드
+    @Column(length = 50)  private String lclsfNm;       // 대분류
+    @Column(length = 50)  private String mclsfNm;       // 중분류
+    @Column(length = 50)  private String aplyYmd;       // 신청기간 (예: "20250312 ~ 20250414")
+    @Column(length = 500) private String aplyUrlAddr;   // 신청 URL
+    @Column(length = 200) private String sprvsnInstCdNm;// 주관기관코드명
+    @Column(length = 200) private String operInstCdNm;  // 운영기관코드명
+
+    public SavedPolicy(User user, String plcyNo,
+                       String plcyNm, String plcyKywdNm,
+                       String lclsfNm, String mclsfNm,
+                       String aplyYmd, String aplyUrlAddr,
+                       String sprvsnInstCdNm, String operInstCdNm) {
+        this.user = user;
+        this.plcyNo = plcyNo;
+        this.plcyNm = plcyNm;
+        this.plcyKywdNm = plcyKywdNm;
+        this.lclsfNm = lclsfNm;
+        this.mclsfNm = mclsfNm;
+        this.aplyYmd = aplyYmd;
+        this.aplyUrlAddr = aplyUrlAddr;
+        this.sprvsnInstCdNm = sprvsnInstCdNm;
+        this.operInstCdNm = operInstCdNm;
+    }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/dto/SavePolicyRequest.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/dto/SavePolicyRequest.java
@@ -1,0 +1,16 @@
+package com.youthjob.api.youthpolicy.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SavePolicyRequest(
+        @NotBlank String plcyNo,
+        // ====== 스냅샷 : 없으면 서버가 외부 API 호출 후 직접 채움 ======
+        String plcyNm,
+        String plcyKywdNm,
+        String lclsfNm,
+        String mclsfNm,
+        String aplyYmd,
+        String aplyUrlAddr,
+        String sprvsnInstCdNm,
+        String operInstCdNm
+) {}

--- a/src/main/java/com/youthjob/api/youthpolicy/dto/SavedPolicyDto.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/dto/SavedPolicyDto.java
@@ -1,0 +1,24 @@
+package com.youthjob.api.youthpolicy.dto;
+
+import com.youthjob.api.youthpolicy.domain.SavedPolicy;
+
+public record SavedPolicyDto(
+        Long id,
+        String plcyNo,
+        String plcyNm,
+        String plcyKywdNm,
+        String lclsfNm,
+        String mclsfNm,
+        String aplyYmd,
+        String aplyUrlAddr,
+        String sprvsnInstCdNm,
+        String operInstCdNm
+) {
+    public static SavedPolicyDto from(SavedPolicy s) {
+        return new SavedPolicyDto(
+                s.getId(), s.getPlcyNo(), s.getPlcyNm(), s.getPlcyKywdNm(),
+                s.getLclsfNm(), s.getMclsfNm(), s.getAplyYmd(), s.getAplyUrlAddr(),
+                s.getSprvsnInstCdNm(), s.getOperInstCdNm()
+        );
+    }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyApiRequestDto.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyApiRequestDto.java
@@ -1,0 +1,22 @@
+package com.youthjob.api.youthpolicy.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.*;
+
+@Getter @NoArgsConstructor @AllArgsConstructor @Builder
+public class YouthPolicyApiRequestDto {
+    // 기본/필수
+    @Builder.Default @Min(1) private Integer pageNum  = 1;
+    @Builder.Default @Min(1) private Integer pageSize = 10;
+    @Builder.Default private Integer pageType = 1;     // 1=목록, 2=상세
+    @Builder.Default private String  rtnType  = "json";
+
+    // 선택 필터
+    private String plcyNo;       // 정책번호
+    private String plcyKywdNm;   // "키워드1,키워드2"
+    private String plcyExpInCn;  // 정책설명
+    private String plcyNm;       // 정책명
+    private String zipCd;        // "11680,41135"
+    private String lclsfNm;      // 대분류명
+    private String mclsfNm;      // 중분류명
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyApiRequestDto.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyApiRequestDto.java
@@ -1,22 +1,65 @@
 package com.youthjob.api.youthpolicy.dto;
 
 import jakarta.validation.constraints.Min;
-import lombok.*;
+import lombok.Getter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
-@Getter @NoArgsConstructor @AllArgsConstructor @Builder
+@Getter
 public class YouthPolicyApiRequestDto {
-    // 기본/필수
-    @Builder.Default @Min(1) private Integer pageNum  = 1;
-    @Builder.Default @Min(1) private Integer pageSize = 10;
-    @Builder.Default private Integer pageType = 1;     // 1=목록, 2=상세
-    @Builder.Default private String  rtnType  = "json";
+
+    // 기본값
+    private String rtnType = "json";
+    @Min(1) private Integer pageNum = 1;
+    @Min(1) private Integer pageSize = 10;
+    /** 화면유형: "1"(목록) / "2"(상세) - 스펙은 String */
+    private String pageType = "1";
 
     // 선택 필터
-    private String plcyNo;       // 정책번호
-    private String plcyKywdNm;   // "키워드1,키워드2"
-    private String plcyExpInCn;  // 정책설명
-    private String plcyNm;       // 정책명
-    private String zipCd;        // "11680,41135"
-    private String lclsfNm;      // 대분류명
-    private String mclsfNm;      // 중분류명
+    private String plcyNo;
+    private String plcyKywdNm;
+    private String plcyNm;
+    /** 정책설명(요청 파라미터 키: plcyExpInCn) */
+    private String plcyExpInCn;
+    private String zipCd;
+    private String lclsfNm;
+    private String mclsfNm;
+
+    // --- 바인딩용 최소 setter들 ---
+    public void setRtnType(String v)     { if (notBlank(v)) this.rtnType = v; }
+    public void setPageNum(Integer v)    { if (v != null && v > 0) this.pageNum = v; }
+    public void setPageSize(Integer v)   { if (v != null && v > 0) this.pageSize = v; }
+    public void setPageType(String v)    { if (notBlank(v)) this.pageType = v; }
+    public void setPlcyNo(String v)      { this.plcyNo = v; }
+    public void setPlcyKywdNm(String v)  { this.plcyKywdNm = v; }
+    public void setPlcyNm(String v)      { this.plcyNm = v; }
+    public void setPlcyExpInCn(String v) { this.plcyExpInCn = v; }
+    public void setZipCd(String v)       { this.zipCd = v; }
+    public void setLclsfNm(String v)     { this.lclsfNm = v; }
+    public void setMclsfNm(String v)     { this.mclsfNm = v; }
+
+    private static boolean notBlank(String s){ return s != null && !s.isBlank(); }
+
+    /** 외부 API 호출용 파라미터 세트 */
+    public MultiValueMap<String, String> toQueryParams(String apiKey){
+        MultiValueMap<String, String> p = new LinkedMultiValueMap<>();
+        // 필수
+        p.add("apiKeyNm", apiKey);
+        p.add("rtnType", rtnType);
+        p.add("pageNum", String.valueOf(pageNum));
+        p.add("pageSize", String.valueOf(pageSize));
+        p.add("pageType", pageType); // String
+        // 선택
+        add(p, "plcyNo", plcyNo);
+        add(p, "plcyKywdNm", plcyKywdNm);
+        add(p, "plcyNm", plcyNm);
+        add(p, "plcyExpInCn", plcyExpInCn); // <-- 요청 키는 ExpIn
+        add(p, "zipCd", zipCd);
+        add(p, "lclsfNm", lclsfNm);
+        add(p, "mclsfNm", mclsfNm);
+        return p;
+    }
+    private static void add(MultiValueMap<String, String> map, String k, String v){
+        if (v != null && !v.isBlank()) map.add(k, v);
+    }
 }

--- a/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyApiResponseDto.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyApiResponseDto.java
@@ -1,0 +1,94 @@
+package com.youthjob.api.youthpolicy.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class YouthPolicyApiResponseDto {
+    private int resultCode;
+    private String resultMessage;
+    private Result result;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Result {
+        private Pagging pagging;
+        private List<Policy> youthPolicyList;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Pagging {
+        private Integer totCount;
+        private Integer pageNum;
+        private Integer pageSize;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Policy {
+        private String plcyNo;
+        private String bscPlanCycl;
+        private String bscPlanPlcyWayNo;
+        private String bscPlanFcsAsmtNo;
+        private String bscPlanAsmtNo;
+        private String pvsnInstGroupCd;
+        private String plcyPvsnMthdCd;
+        private String plcyAprvSttsCd;
+        private String plcyNm;
+        private String plcyKywdNm;
+        private String plcyExplnCn;
+        private String lclsfNm;
+        private String mclsfNm;
+        private String plcySprtCn;
+        private String sprvsnInstCd;
+        private String sprvsnInstCdNm;
+        private String sprvsnInstPicNm;
+        private String operInstCd;
+        private String operInstCdNm;
+        private String operInstPicNm;
+        private String sprtSclLmtYn;
+        private String aplyPrdSeCd;
+        private String bizPrdSeCd;
+        private String bizPrdBgngYmd;
+        private String bizPrdEndYmd;
+        private String bizPrdEtcCn;
+        private String plcyAplyMthdCn;
+        private String srngMthdCn;
+        private String aplyUrlAddr;
+        private String sbmsnDcmntCn;
+        private String etcMttrCn;
+        private String refUrlAddr1;
+        private String refUrlAddr2;
+        private String sprtSclCnt;
+        private String sprtArvlSeqYn;
+        private String sprtTrgtMinAge;
+        private String sprtTrgtMaxAge;
+        private String sprtTrgtAgeLmtYn;
+        private String mrgSttsCd;
+        private String earnCndSeCd;
+        private String earnMinAmt;
+        private String earnMaxAmt;
+        private String earnEtcCn;
+        private String addAplyQlfcCndCn;
+        private String ptcpPrpTrgtCn;
+        private String inqCnt;
+        private String rgtrInstCd;
+        private String rgtrInstCdNm;
+        private String rgtrUpInstCd;
+        private String rgtrUpInstCdNm;
+        private String rgtrHghrkInstCd;
+        private String rgtrHghrkInstCdNm;
+        private String zipCd;
+        private String plcyMajorCd;
+        private String jobCd;
+        private String schoolCd;
+        private String aplyYmd;
+        private String frstRegDt;
+        private String lastMdfcnDt;
+        private String sbizCd;
+    }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyApiResponseDto.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyApiResponseDto.java
@@ -1,12 +1,15 @@
 package com.youthjob.api.youthpolicy.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.Getter;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class YouthPolicyApiResponseDto {
     private int resultCode;
     private String resultMessage;
@@ -14,6 +17,9 @@ public class YouthPolicyApiResponseDto {
 
     @Getter
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder(toBuilder = true)
     public static class Result {
         private Pagging pagging;
         private List<Policy> youthPolicyList;
@@ -21,6 +27,9 @@ public class YouthPolicyApiResponseDto {
 
     @Getter
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder(toBuilder = true)
     public static class Pagging {
         private Integer totCount;
         private Integer pageNum;
@@ -29,6 +38,9 @@ public class YouthPolicyApiResponseDto {
 
     @Getter
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder(toBuilder = true)
     public static class Policy {
         private String plcyNo;
         private String bscPlanCycl;

--- a/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyDetailDto.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyDetailDto.java
@@ -1,0 +1,17 @@
+package com.youthjob.api.youthpolicy.dto;
+
+import lombok.Builder;
+
+@Builder
+public record YouthPolicyDetailDto(
+        String plcyNo,
+        String plcyNm,
+        String plcyKywdNm,
+        String plcyExplnCn,
+        String lclsfNm,
+        String mclsfNm,
+        String aplyYmd,
+        String aplyUrlAddr,
+        String sprvsnInstCdNm,
+        String operInstCdNm
+) {}

--- a/src/main/java/com/youthjob/api/youthpolicy/repository/SavedPolicyRepository.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/repository/SavedPolicyRepository.java
@@ -1,0 +1,15 @@
+package com.youthjob.api.youthpolicy.repository;
+
+import com.youthjob.api.auth.domain.User;
+import com.youthjob.api.youthpolicy.domain.SavedPolicy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SavedPolicyRepository extends JpaRepository<SavedPolicy, Long> {
+    List<SavedPolicy> findAllByUserOrderByCreatedAtDesc(User user);
+    boolean existsByUserAndPlcyNo(User user, String plcyNo);
+    Optional<SavedPolicy> findByIdAndUser(Long id, User user);
+    Optional<SavedPolicy> findByUserAndPlcyNo(User user, String plcyNo);
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/service/YouthPolicyFavoriteService.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/service/YouthPolicyFavoriteService.java
@@ -1,0 +1,126 @@
+package com.youthjob.api.youthpolicy.service;
+
+import com.youthjob.api.auth.domain.User;
+import com.youthjob.api.auth.repository.UserRepository;
+import com.youthjob.api.youthpolicy.domain.SavedPolicy;
+import com.youthjob.api.youthpolicy.dto.SavePolicyRequest;
+import com.youthjob.api.youthpolicy.dto.SavedPolicyDto;
+import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto;
+import com.youthjob.api.youthpolicy.client.YouthPolicyClient;
+import com.youthjob.api.youthpolicy.repository.SavedPolicyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class YouthPolicyFavoriteService {
+
+    private final SavedPolicyRepository savedPolicyRepository;
+    private final YouthPolicyClient client;
+    private final UserRepository userRepository;
+
+    public List<SavedPolicyDto> listSaved() {
+        User me = currentUser();
+        return savedPolicyRepository.findAllByUserOrderByCreatedAtDesc(me)
+                .stream().map(SavedPolicyDto::from).toList();
+    }
+
+    @Transactional
+    public SavedPolicyDto save(SavePolicyRequest req) {
+        User me = currentUser();
+
+        // 이미 있으면 그대로 반환
+        var existed = savedPolicyRepository.findByUserAndPlcyNo(me, req.plcyNo());
+        if (existed.isPresent()) return SavedPolicyDto.from(existed.get());
+
+        // 스냅샷이 충분하면 그대로, 아니면 외부 API에서 채움
+        Snapshot snap = snapshotOrFetch(req);
+
+        SavedPolicy saved = new SavedPolicy(
+                me,
+                req.plcyNo(),
+                snap.plcyNm, snap.plcyKywdNm,
+                snap.lclsfNm, snap.mclsfNm,
+                snap.aplyYmd, snap.aplyUrlAddr,
+                snap.sprvsnInstCdNm, snap.operInstCdNm
+        );
+        return SavedPolicyDto.from(savedPolicyRepository.save(saved));
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        User me = currentUser();
+        var target = savedPolicyRepository.findByIdAndUser(id, me)
+                .orElseThrow(() -> new IllegalArgumentException("삭제할 항목을 찾을 수 없습니다."));
+        savedPolicyRepository.delete(target);
+    }
+
+    /** 없으면 저장, 있으면 삭제하고 null 반환 (HRD 스타일) */
+    @Transactional
+    public SavedPolicyDto toggle(SavePolicyRequest req) {
+        User me = currentUser();
+        var existed = savedPolicyRepository.findByUserAndPlcyNo(me, req.plcyNo());
+        if (existed.isPresent()) {
+            savedPolicyRepository.delete(existed.get());
+            return null;
+        }
+        return save(req);
+    }
+
+    // ===== 내부 유틸 =====
+    private User currentUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getName() == null) {
+            throw new IllegalStateException("인증 정보가 없습니다.");
+        }
+        return userRepository.findByEmail(auth.getName())
+                .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다: " + auth.getName()));
+    }
+
+    private record Snapshot(
+            String plcyNm, String plcyKywdNm,
+            String lclsfNm, String mclsfNm,
+            String aplyYmd, String aplyUrlAddr,
+            String sprvsnInstCdNm, String operInstCdNm
+    ) {}
+
+    /** 요청에 스냅샷이 충분하면 그대로, 아니면 plcyNo로 외부API 상세 조회해서 채움 */
+    private Snapshot snapshotOrFetch(SavePolicyRequest req) {
+        boolean hasSnapshot =
+                notBlank(req.plcyNm()) || notBlank(req.plcyKywdNm()) ||
+                notBlank(req.lclsfNm()) || notBlank(req.mclsfNm()) ||
+                notBlank(req.aplyYmd()) || notBlank(req.aplyUrlAddr()) ||
+                notBlank(req.sprvsnInstCdNm()) || notBlank(req.operInstCdNm());
+
+        if (hasSnapshot) {
+            return new Snapshot(
+                    req.plcyNm(), req.plcyKywdNm(),
+                    req.lclsfNm(), req.mclsfNm(),
+                    req.aplyYmd(), req.aplyUrlAddr(),
+                    req.sprvsnInstCdNm(), req.operInstCdNm()
+            );
+        }
+
+        // 외부 API 상세 조회 (pageType=2)
+        YouthPolicyApiResponseDto resp = client.findByPlcyNo(req.plcyNo());
+        var list = resp != null && resp.getResult() != null ? resp.getResult().getYouthPolicyList() : null;
+        var p = (list != null && !list.isEmpty()) ? list.get(0) : null;
+        if (p == null) throw new IllegalStateException("plcyNo 상세를 찾을 수 없습니다: " + req.plcyNo());
+
+        return new Snapshot(
+                p.getPlcyNm(), p.getPlcyKywdNm(),
+                p.getLclsfNm(), p.getMclsfNm(),
+                p.getAplyYmd(), p.getAplyUrlAddr(),
+                p.getSprvsnInstCdNm(), p.getOperInstCdNm()
+        );
+    }
+
+    private static boolean notBlank(String s) {
+        return s != null && !s.isBlank();
+    }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/service/YouthPolicyService.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/service/YouthPolicyService.java
@@ -1,0 +1,105 @@
+package com.youthjob.api.youthpolicy.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.youthjob.api.youthpolicy.client.YouthPolicyClient;
+import com.youthjob.api.youthpolicy.dto.YouthPolicyApiRequestDto;
+import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto;
+import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto.Policy; // <-- 올바른 import
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class YouthPolicyService {
+
+    private final YouthPolicyClient client;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public YouthPolicyApiResponseDto searchWithFilter(YouthPolicyApiRequestDto req) {
+        YouthPolicyApiResponseDto raw = client.search(req);
+        if (raw == null || raw.getResult() == null || raw.getResult().getYouthPolicyList() == null) {
+            return raw;
+        }
+
+        List<Policy> list = raw.getResult().getYouthPolicyList();
+
+        // ==== 서버단 후처리 필터 ====
+        if (notBlank(req.getPlcyKywdNm())) {
+            String kw = req.getPlcyKywdNm().trim();
+            list = list.stream()
+                    .filter(p -> containsAnyToken(p.getPlcyKywdNm(), kw))
+                    .collect(Collectors.toList());
+        }
+        if (notBlank(req.getPlcyNm())) {
+            String kw = req.getPlcyNm().trim();
+            list = list.stream()
+                    .filter(p -> contains(p.getPlcyNm(), kw))
+                    .collect(Collectors.toList());
+        }
+        if (notBlank(req.getPlcyExpInCn())) { // 요청 키 기준 설명 필터(부분일치)
+            String kw = req.getPlcyExpInCn().trim();
+            list = list.stream()
+                    .filter(p -> contains(p.getPlcyExplnCn(), kw))
+                    .collect(Collectors.toList());
+        }
+        if (notBlank(req.getZipCd())) {
+            String kw = req.getZipCd().trim();
+            list = list.stream()
+                    .filter(p -> contains(p.getZipCd(), kw))
+                    .collect(Collectors.toList());
+        }
+        if (notBlank(req.getLclsfNm())) {
+            String kw = req.getLclsfNm().trim();
+            list = list.stream()
+                    .filter(p -> contains(p.getLclsfNm(), kw))
+                    .collect(Collectors.toList());
+        }
+        if (notBlank(req.getMclsfNm())) {
+            String kw = req.getMclsfNm().trim();
+            list = list.stream()
+                    .filter(p -> contains(p.getMclsfNm(), kw))
+                    .collect(Collectors.toList());
+        }
+
+        // ==== 서버단 페이징(외부 pageSize 무시 대비) ====
+        int pageNum  = Optional.ofNullable(req.getPageNum()).orElse(1);
+        int pageSize = Optional.ofNullable(req.getPageSize()).orElse(10);
+        int from = Math.max(0, (pageNum - 1) * pageSize);
+        int to   = Math.min(list.size(), from + pageSize);
+        List<Policy> pageSlice = from < to ? list.subList(from, to) : List.of();
+
+        // ==== setter 없이 응답 재구성 ====
+        Map<String, Object> tree = mapper.convertValue(raw, new TypeReference<>() {});
+        Map<String, Object> result = castMap(tree.get("result"));
+        Map<String, Object> pagging = castMap(result.get("pagging"));
+
+        result.put("youthPolicyList",
+                mapper.convertValue(pageSlice, new TypeReference<List<Map<String,Object>>>(){}));
+        pagging.put("totCount", list.size());
+        pagging.put("pageNum", pageNum);
+        pagging.put("pageSize", pageSize);
+
+        return mapper.convertValue(tree, YouthPolicyApiResponseDto.class);
+    }
+
+    private static boolean notBlank(String s){ return s != null && !s.isBlank(); }
+    private static boolean contains(String src, String kw){ return src != null && src.contains(kw); }
+
+    /** "교육지원,보조금" 같은 콤마 구분 키워드에서 부분일치 허용 */
+    private static boolean containsAnyToken(String src, String kw){
+        if (src == null || kw == null || kw.isBlank()) return false;
+        return Stream.of(src.split("[,，]"))
+                .map(String::trim)
+                .anyMatch(t -> t.contains(kw));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String,Object> castMap(Object o){
+        return o instanceof Map ? (Map<String, Object>) o : new HashMap<>();
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 청년정책 오픈 API 연동 및 호출
- 관심 정책 저장/삭제/조회/토글 기능 구현(마이페이지에서 활용)
  - SavedPolicy 엔티티 및 Repository 추가(DB)
  - YouthPolicyFavoriteService 로직 및 예외 처리 정비
  - 관심 정책 스냅샷 저장 구조 적용(DB저장)
- 청년정책 검색 필터 동작 오류 수정
  - plcyKywdNm, plcyNm, zipCd, lclsfNm, mclsfNm 필터 적용 로직 보완
  - 응답 pagination 정보(totCount, pageNum, pageSize) 정상 반영

## ➕ 이슈 링크
* Closes #7 

## 테스트 방법(POSTMAN)
- GET "/api/v1/youth-policies?plcyKywdNm=보조금&pageNum=1&pageSize=10" : 검색 필터 확인
- GET "/api/v1/youth-policies/{plcyNo}" : 정책 상세 조회
- GET "/api/v1/youth-policies/saved" : 관심 정책 목록 조회
- POST "/api/v1/youth-policies/saved" : 관심 정책 저장
- DELETE "/api/v1/youth-policies/saved/{id}" : 관심 정책 삭제
- POST "/api/v1/youth-policies/saved/toggle" : 관심 정책 토글

## 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)
- [x] 검색 필터 및 관심 정책 기능 로컬 수동 테스트 완료(POSTMAN)

## 📸 스크린샷(선택)
