### PR TITLE
Feat/#22 mypage

### DIFF
--- a/src/main/java/com/youthjob/api/auth/domain/Gender.java
+++ b/src/main/java/com/youthjob/api/auth/domain/Gender.java
@@ -1,0 +1,5 @@
+package com.youthjob.api.auth.domain;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/youthjob/api/auth/domain/User.java
+++ b/src/main/java/com/youthjob/api/auth/domain/User.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 프록시/리플렉션용
 @Table(name = "users",
-       indexes = @Index(name="uk_users_email", columnList="email", unique = true))
+        indexes = @Index(name="uk_users_email", columnList="email", unique = true))
 public class User extends BaseTimeEntity implements UserDetails {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,6 +34,10 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     @Column(length=500)
     private String refreshToken;
+
+    // ===== 마이페이지에서 수정할 이름 -> 선택사항 =====
+    @Column(length = 30)
+    private String name;
 
     @Builder(access = AccessLevel.PRIVATE)
     private User(String email, String password, Role role) {
@@ -69,6 +73,11 @@ public class User extends BaseTimeEntity implements UserDetails {
             throw new IllegalArgumentException("encodedPassword required");
         }
         this.password = encodedPassword;
+    }
+
+    /** 마이페이지: 이름만 부분 업데이트(null은 미변경) */
+    public void updateName(String name) {
+        if (name != null) this.name = name;
     }
 
     // === UserDetails ===

--- a/src/main/java/com/youthjob/api/empprogram/repository/SavedEmpProgramRepository.java
+++ b/src/main/java/com/youthjob/api/empprogram/repository/SavedEmpProgramRepository.java
@@ -2,6 +2,8 @@ package com.youthjob.api.empprogram.repository;
 
 import com.youthjob.api.empprogram.domain.SavedEmpProgram;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +12,8 @@ public interface SavedEmpProgramRepository extends JpaRepository<SavedEmpProgram
     boolean existsByMemberIdAndExtKey(Long memberId, String extKey);
     Optional<SavedEmpProgram> findByMemberIdAndExtKey(Long memberId, String extKey);
     List<SavedEmpProgram> findByMemberIdOrderByIdDesc(Long memberId);
+
+    // === 추가: 마이페이지용 ===
+    Page<SavedEmpProgram> findByMemberId(Long memberId, Pageable pageable);
+    long countByMemberId(Long memberId);
 }

--- a/src/main/java/com/youthjob/api/hrd/repository/SavedCourseRepository.java
+++ b/src/main/java/com/youthjob/api/hrd/repository/SavedCourseRepository.java
@@ -11,14 +11,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface SavedCourseRepository extends JpaRepository<SavedCourse, Long> {
-
     boolean existsByUserAndTrprIdAndTrprDegr(User user, String trprId, String trprDegr);
-
     List<SavedCourse> findAllByUserOrderByCreatedAtDesc(User user);
-
     Optional<SavedCourse> findByIdAndUser(Long id, User user);
 
-    // 추가
+    // === 추가: 마이페이지용 ===
     Page<SavedCourse> findByUser(User user, Pageable pageable);
     long countByUser(User user);
 }

--- a/src/main/java/com/youthjob/api/hrd/repository/SavedCourseRepository.java
+++ b/src/main/java/com/youthjob/api/hrd/repository/SavedCourseRepository.java
@@ -4,6 +4,8 @@ package com.youthjob.api.hrd.repository;
 import com.youthjob.api.auth.domain.User;
 import com.youthjob.api.hrd.domain.SavedCourse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +17,8 @@ public interface SavedCourseRepository extends JpaRepository<SavedCourse, Long> 
     List<SavedCourse> findAllByUserOrderByCreatedAtDesc(User user);
 
     Optional<SavedCourse> findByIdAndUser(Long id, User user);
+
+    // 추가
+    Page<SavedCourse> findByUser(User user, Pageable pageable);
+    long countByUser(User user);
 }

--- a/src/main/java/com/youthjob/api/hrd/service/HrdSearchService.java
+++ b/src/main/java/com/youthjob/api/hrd/service/HrdSearchService.java
@@ -222,8 +222,6 @@ public class HrdSearchService {
                 .build();
     }
 
-
-
     private static String extractQuery(String url, String key) {
         try {
             var uri = new java.net.URI(url);
@@ -256,7 +254,6 @@ public class HrdSearchService {
         return null;
     }
 
-
     // 여러 후보 키 중 첫 번째로 존재하는 노드 반환
     private static JsonNode node(JsonNode parent, String... keys) {
         if (parent == null) return missing();
@@ -266,6 +263,7 @@ public class HrdSearchService {
         }
         return missing();
     }
+
     private static JsonNode missing() {
         return com.fasterxml.jackson.databind.node.MissingNode.getInstance();
     }

--- a/src/main/java/com/youthjob/api/mypage/controller/MyPageController.java
+++ b/src/main/java/com/youthjob/api/mypage/controller/MyPageController.java
@@ -1,5 +1,6 @@
 package com.youthjob.api.mypage.controller;
 
+import com.youthjob.api.empprogram.dto.SavedEmpProgramDto;
 import com.youthjob.api.hrd.dto.SavedCourseDto;
 import com.youthjob.api.mypage.dto.*;
 import com.youthjob.api.mypage.service.MyPageService;
@@ -34,13 +35,13 @@ public class MyPageController {
         return ResponseEntity.ok(service.updateProfile(req));
     }
 
-//    /** 관심 - 취업역량 강화 프로그램 */
-//    @GetMapping("/saved-capabilities")
-//    public ResponseEntity<PageResult<SavedCapabilityDto>> savedCapabilities(
-//            @RequestParam(defaultValue = "0") int page,
-//            @RequestParam(defaultValue = "10") int size) {
-//        return ResponseEntity.ok(service.savedCapabilities(page, size));
-//    }
+    /** 관심 - 취업역량 강화프로그램 */
+    @GetMapping("/saved-emp-programs")
+    public ResponseEntity<PageResult<SavedEmpProgramDto>> savedEmpPrograms(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(service.savedEmpPrograms(page, size));
+    }
 
     /** 관심 - 내일배움카드 */
     @GetMapping("/saved-courses")

--- a/src/main/java/com/youthjob/api/mypage/controller/MyPageController.java
+++ b/src/main/java/com/youthjob/api/mypage/controller/MyPageController.java
@@ -1,0 +1,60 @@
+package com.youthjob.api.mypage.controller;
+
+import com.youthjob.api.hrd.dto.SavedCourseDto;
+import com.youthjob.api.mypage.dto.*;
+import com.youthjob.api.mypage.service.MyPageService;
+import com.youthjob.api.youthpolicy.dto.SavedPolicyDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mypage")
+public class MyPageController {
+
+    private final MyPageService service;
+
+    /** 상단 프로필 + 카운트 */
+    @GetMapping("/summary")
+    public ResponseEntity<MyPageSummaryDto> summary() {
+        return ResponseEntity.ok(service.summary());
+    }
+
+    /** 내 정보 단독 조회 (수정 화면 초기값) */
+    @GetMapping("/profile")
+    public ResponseEntity<ProfileDto> profile() {
+        return ResponseEntity.ok(service.profile());
+    }
+
+    /** 내 정보 수정: 이름 */
+    @PutMapping("/profile")
+    public ResponseEntity<ProfileDto> updateProfile(@RequestBody @Valid UpdateMyInfoRequest req) {
+        return ResponseEntity.ok(service.updateProfile(req));
+    }
+
+//    /** 관심 - 취업역량 강화 프로그램 */
+//    @GetMapping("/saved-capabilities")
+//    public ResponseEntity<PageResult<SavedCapabilityDto>> savedCapabilities(
+//            @RequestParam(defaultValue = "0") int page,
+//            @RequestParam(defaultValue = "10") int size) {
+//        return ResponseEntity.ok(service.savedCapabilities(page, size));
+//    }
+
+    /** 관심 - 내일배움카드 */
+    @GetMapping("/saved-courses")
+    public ResponseEntity<PageResult<SavedCourseDto>> savedCourses(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(service.savedCourses(page, size));
+    }
+
+    /** 관심 - 청년정책 */
+    @GetMapping("/saved-policies")
+    public ResponseEntity<PageResult<SavedPolicyDto>> savedPolicies(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(service.savedPolicies(page, size));
+    }
+}

--- a/src/main/java/com/youthjob/api/mypage/dto/CountersDto.java
+++ b/src/main/java/com/youthjob/api/mypage/dto/CountersDto.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record CountersDto(
-       //  long savedCapabilities,  // 취업역량 강화
+        long savedEmpPrograms,   // 취업역량 강화프로그램
         long savedCourses,       // 내일배움카드
         long savedPolicies       // 청년정책
 ) {}

--- a/src/main/java/com/youthjob/api/mypage/dto/CountersDto.java
+++ b/src/main/java/com/youthjob/api/mypage/dto/CountersDto.java
@@ -1,0 +1,10 @@
+package com.youthjob.api.mypage.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CountersDto(
+       //  long savedCapabilities,  // 취업역량 강화
+        long savedCourses,       // 내일배움카드
+        long savedPolicies       // 청년정책
+) {}

--- a/src/main/java/com/youthjob/api/mypage/dto/MyPageSummaryDto.java
+++ b/src/main/java/com/youthjob/api/mypage/dto/MyPageSummaryDto.java
@@ -1,0 +1,9 @@
+package com.youthjob.api.mypage.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MyPageSummaryDto(
+        ProfileDto profile,
+        CountersDto counters
+) {}

--- a/src/main/java/com/youthjob/api/mypage/dto/PageResult.java
+++ b/src/main/java/com/youthjob/api/mypage/dto/PageResult.java
@@ -1,0 +1,9 @@
+package com.youthjob.api.mypage.dto;
+
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record PageResult<T>(
+        int page, int size, long totalElements, int totalPages, List<T> items
+) {}

--- a/src/main/java/com/youthjob/api/mypage/dto/ProfileDto.java
+++ b/src/main/java/com/youthjob/api/mypage/dto/ProfileDto.java
@@ -1,0 +1,12 @@
+package com.youthjob.api.mypage.dto;
+
+import lombok.Builder;
+import java.time.LocalDateTime;
+
+@Builder
+public record ProfileDto(
+        String displayName,   // name 있으면 name, 없으면 이메일 local-part
+        String email,
+        LocalDateTime joinedAt,
+        String name           // 저장된 이름(수정 화면 초기값)
+) {}

--- a/src/main/java/com/youthjob/api/mypage/dto/UpdateMyInfoRequest.java
+++ b/src/main/java/com/youthjob/api/mypage/dto/UpdateMyInfoRequest.java
@@ -1,0 +1,9 @@
+package com.youthjob.api.mypage.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+public record UpdateMyInfoRequest(
+        @Size(min = 1, max = 30) String name
+) {}

--- a/src/main/java/com/youthjob/api/mypage/service/MyPageService.java
+++ b/src/main/java/com/youthjob/api/mypage/service/MyPageService.java
@@ -1,0 +1,125 @@
+package com.youthjob.api.mypage.service;
+
+import com.youthjob.api.auth.domain.User;
+import com.youthjob.api.auth.repository.UserRepository;
+import com.youthjob.api.hrd.dto.SavedCourseDto;
+import com.youthjob.api.hrd.repository.SavedCourseRepository;
+import com.youthjob.api.mypage.dto.*;
+import com.youthjob.api.youthpolicy.dto.SavedPolicyDto;
+import com.youthjob.api.youthpolicy.repository.SavedPolicyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    // private final SavedCapabilityRepository savedCapabilityRepository;
+    private final SavedCourseRepository savedCourseRepository;
+    private final SavedPolicyRepository savedPolicyRepository;
+
+    /** 상단 프로필 + 카운트 */
+    public MyPageSummaryDto summary() {
+        User me = currentUser();
+
+        // long capCnt  = savedCapabilityRepository.countByUser(me);
+        long hrdCnt  = savedCourseRepository.countByUser(me);
+        long polCnt  = savedPolicyRepository.countByUser(me);
+
+        return MyPageSummaryDto.builder()
+                .profile(toProfileDto(me))
+                .counters(CountersDto.builder()
+                        // .savedCapabilities(capCnt)
+                        .savedCourses(hrdCnt)
+                        .savedPolicies(polCnt)
+                        .build())
+                .build();
+    }
+
+    /** 내 정보 단독 조회 (수정 화면 초기값) */
+    public ProfileDto profile() {
+        return toProfileDto(currentUser());
+    }
+
+    /** 내 정보 수정: 이름만 부분 업데이트 */
+    @Transactional
+    public ProfileDto updateProfile(UpdateMyInfoRequest req) {
+        User me = currentUser();
+        me.updateName(req.name());
+        return toProfileDto(me); // dirty checking
+    }
+
+//    /** 취업역량 강화 프로그램 (관심) 페이징 */
+//    public PageResult<SavedCapabilityDto> savedCapabilities(int page, int size) {
+//        User me = currentUser();
+//        Pageable pageable = PageRequest.of(Math.max(page,0), Math.min(Math.max(size,1),100),
+//                Sort.by(Sort.Direction.DESC, "createdAt"));
+//        var p = savedCapabilityRepository.findByUser(me, pageable)
+//                .map(SavedCapabilityDto::from);
+//        return PageResult.<SavedCapabilityDto>builder()
+//                .page(p.getNumber()).size(p.getSize())
+//                .totalElements(p.getTotalElements()).totalPages(p.getTotalPages())
+//                .items(p.getContent())
+//                .build();
+//    }
+
+    /** 내일배움카드(관심) 페이징 */
+    public PageResult<SavedCourseDto> savedCourses(int page, int size) {
+        User me = currentUser();
+        Pageable pageable = PageRequest.of(Math.max(page,0), Math.min(Math.max(size,1),100),
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+        var p = savedCourseRepository.findByUser(me, pageable)
+                .map(SavedCourseDto::from);
+        return PageResult.<SavedCourseDto>builder()
+                .page(p.getNumber()).size(p.getSize())
+                .totalElements(p.getTotalElements()).totalPages(p.getTotalPages())
+                .items(p.getContent())
+                .build();
+    }
+
+    /** 청년정책(관심) 페이징 */
+    public PageResult<SavedPolicyDto> savedPolicies(int page, int size) {
+        User me = currentUser();
+        Pageable pageable = PageRequest.of(Math.max(page,0), Math.min(Math.max(size,1),100),
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+        var p = savedPolicyRepository.findByUser(me, pageable)
+                .map(SavedPolicyDto::from);
+        return PageResult.<SavedPolicyDto>builder()
+                .page(p.getNumber()).size(p.getSize())
+                .totalElements(p.getTotalElements()).totalPages(p.getTotalPages())
+                .items(p.getContent())
+                .build();
+    }
+
+    // ===== 내부 유틸 =====
+    private User currentUser() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getName() == null || "anonymousUser".equals(auth.getName())) {
+            throw new IllegalStateException("인증 필요");
+        }
+        return userRepository.findByEmail(auth.getName())
+                .orElseThrow(() -> new IllegalStateException("사용자를 찾을 수 없습니다: " + auth.getName()));
+    }
+
+    private ProfileDto toProfileDto(User me) {
+        String displayName = (me.getName() != null && !me.getName().isBlank())
+                ? me.getName()
+                : deriveLocalPart(me.getEmail());
+
+        return ProfileDto.builder()
+                .displayName(displayName)
+                .email(me.getEmail())
+                .joinedAt(me.getCreatedAt())
+                .name(me.getName())
+                .build();
+    }
+    private String deriveLocalPart(String email) {
+        if (email == null) return "사용자";
+        int idx = email.indexOf('@');
+        return idx > 0 ? email.substring(0, idx) : email;
+    }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/repository/SavedPolicyRepository.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/repository/SavedPolicyRepository.java
@@ -15,7 +15,7 @@ public interface SavedPolicyRepository extends JpaRepository<SavedPolicy, Long> 
     Optional<SavedPolicy> findByIdAndUser(Long id, User user);
     Optional<SavedPolicy> findByUserAndPlcyNo(User user, String plcyNo);
 
-    // 추가
+    // === 추가: 마이페이지용 ===
     Page<SavedPolicy> findByUser(User user, Pageable pageable);
     long countByUser(User user);
 }

--- a/src/main/java/com/youthjob/api/youthpolicy/repository/SavedPolicyRepository.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/repository/SavedPolicyRepository.java
@@ -3,6 +3,8 @@ package com.youthjob.api.youthpolicy.repository;
 import com.youthjob.api.auth.domain.User;
 import com.youthjob.api.youthpolicy.domain.SavedPolicy;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +14,8 @@ public interface SavedPolicyRepository extends JpaRepository<SavedPolicy, Long> 
     boolean existsByUserAndPlcyNo(User user, String plcyNo);
     Optional<SavedPolicy> findByIdAndUser(Long id, User user);
     Optional<SavedPolicy> findByUserAndPlcyNo(User user, String plcyNo);
+
+    // 추가
+    Page<SavedPolicy> findByUser(User user, Pageable pageable);
+    long countByUser(User user);
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 프로필/관심항목 조회·수정 기능 구현
  - 관심 항목 카운트 및 페이징 연동(취업역량 강화프로그램/내일배움카드/청년정책)
- 마이페이지 응답/페이징 동작 정비
  - 상단 요약: 프로필(이름/이메일/가입일) + 관심 항목 수
  - 관심 목록 정렬(createdAt DESC) 및 pagination(page, size, total*) 정상 반영

## ➕ 이슈 링크
* Closes #22 

## 테스트 방법(POSTMAN)
- GET "/api/v1/mypage/summary" : 마이페이지 상단 요약(프로필+카운트) 조회
- GET "/api/v1/mypage/profile" : 내 프로필 조회
- PUT "/api/v1/mypage/profile" : 내 정보 수정(Body: {"name":"홍길동"})
- GET "/api/v1/mypage/saved-emp-programs?page=0&size=10" : 관심 취업역량 강화프로그램 목록
- GET "/api/v1/mypage/saved-courses?page=0&size=10" : 관심 내일배움카드 목록
- GET "/api/v1/mypage/saved-policies?page=0&size=10" : 관심 청년정책 목록

## 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)
- [x] 검색 필터 및 관심 정책 기능 로컬 수동 테스트 완료(POSTMAN)

## 📸 스크린샷(선택)