### PR TITLE
fix(youthpolicydetail): 청년정책 상세보기 DTO 개선 및 매퍼 도입 (코드→라벨 변환)(#36)

### DIFF
--- a/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyController.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyController.java
@@ -1,15 +1,16 @@
 package com.youthjob.api.youthpolicy.controller;
 
+import com.youthjob.api.youthpolicy.client.YouthPolicyClient;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyApiRequestDto;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyDetailDto;
+import com.youthjob.api.youthpolicy.service.YouthPolicyMapper;
 import com.youthjob.api.youthpolicy.service.YouthPolicyService;
-import com.youthjob.api.youthpolicy.client.YouthPolicyClient;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-        import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,13 +20,13 @@ public class YouthPolicyController {
     private final YouthPolicyService service;
     private final YouthPolicyClient client;
 
-    /** 검색 + 후처리 필터 호출 예: /api/v1/youth-policies?plcyKywdNm=보조금&pageNum=1&pageSize=10 */
+    /** 검색 + 후처리 필터: /api/v1/youth-policies?plcyKywdNm=보조금&pageNum=1&pageSize=10 */
     @GetMapping
     public YouthPolicyApiResponseDto list(@Valid @ModelAttribute YouthPolicyApiRequestDto req) {
         return service.searchWithFilter(req);
     }
 
-    /** 각 정책별 상세정보: /api/v1/youth-policies/{plcyNo} */
+    /** 상세: /api/v1/youth-policies/{plcyNo} */
     @GetMapping("/{plcyNo}")
     public YouthPolicyDetailDto detail(@PathVariable String plcyNo) {
         var resp = client.findByPlcyNo(plcyNo);
@@ -34,20 +35,7 @@ public class YouthPolicyController {
                 resp.getResult().getYouthPolicyList().isEmpty()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "정책을 찾을 수 없습니다: " + plcyNo);
         }
-
         var p = resp.getResult().getYouthPolicyList().get(0);
-
-        return YouthPolicyDetailDto.builder()
-                .plcyNo(p.getPlcyNo())
-                .plcyNm(p.getPlcyNm())
-                .plcyKywdNm(p.getPlcyKywdNm())
-                .plcyExplnCn(p.getPlcyExplnCn())
-                .lclsfNm(p.getLclsfNm())
-                .mclsfNm(p.getMclsfNm())
-                .aplyYmd(p.getAplyYmd())
-                .aplyUrlAddr(p.getAplyUrlAddr())
-                .sprvsnInstCdNm(p.getSprvsnInstCdNm())
-                .operInstCdNm(p.getOperInstCdNm())
-                .build();
+        return YouthPolicyMapper.toDetail(p);
     }
 }

--- a/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyDetailDto.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/dto/YouthPolicyDetailDto.java
@@ -2,16 +2,69 @@ package com.youthjob.api.youthpolicy.dto;
 
 import lombok.Builder;
 
+import java.util.List;
+
 @Builder
 public record YouthPolicyDetailDto(
+        // === 기본 요약 ===
         String plcyNo,
         String plcyNm,
-        String plcyKywdNm,
-        String plcyExplnCn,
-        String lclsfNm,
-        String mclsfNm,
-        String aplyYmd,
-        String aplyUrlAddr,
-        String sprvsnInstCdNm,
-        String operInstCdNm
+        String summary,                 // plcyExplnCn
+        List<String> keywords,          // plcyKywdNm (콤마 분리)
+        String categoryL,               // lclsfNm
+        String categoryM,               // mclsfNm
+
+        // === 신청/기간/방법 ===
+        String applyPeriodType,         // aplyPrdSeCd 라벨(특정기간/상시/마감)
+        String applyPeriod,             // aplyYmd
+        String applyUrl,                // aplyUrlAddr
+        String applyMethod,             // plcyAplyMthdCn
+
+        // === 지원내용/선착순/규모 ===
+        String supportContent,          // plcySprtCn
+        Boolean firstCome,              // sprtArvlSeqYn == 'Y'
+        Boolean supportScaleLimited,    // sprtSclLmtYn == 'Y'
+        Integer supportCount,           // sprtSclCnt
+
+        // === 자격요건 ===
+        Integer ageMin,                 // sprtTrgtMinAge
+        Integer ageMax,                 // sprtTrgtMaxAge
+        Boolean ageLimited,             // sprtTrgtAgeLmtYn == 'Y'
+        String maritalStatus,           // mrgSttsCd 라벨
+        String incomeConditionType,     // earnCndSeCd 라벨
+        String incomeMin,               // earnMinAmt
+        String incomeMax,               // earnMaxAmt
+        String incomeEtc,               // earnEtcCn
+        List<String> jobRequirements,   // jobCd 라벨 리스트
+        String majorRequirement,        // plcyMajorCd 라벨
+        List<String> schoolRequirements,// schoolCd 라벨 리스트
+        List<String> specialRequirements,// sbizCd 라벨 리스트
+        String additionalQualification, // addAplyQlfcCndCn
+        String participantTarget,       // ptcpPrpTrgtCn
+
+        // === 심사/제출/비고 ===
+        String screeningMethod,         // srngMthdCn
+        String requiredDocs,            // sbmsnDcmntCn
+        String etcNotes,                // etcMttrCn
+        List<String> refUrls,           // refUrlAddr1/2
+
+        // === 기관/담당 ===
+        String providerGroup,           // pvsnInstGroupCd 라벨
+        String provisionMethod,         // plcyPvsnMthdCd 라벨
+        String supervisorName,          // sprvsnInstCdNm
+        String operatorName,            // operInstCdNm
+        String supervisorContactName,   // sprvsnInstPicNm
+        String operatorContactName,     // operInstPicNm
+
+        // === 사업기간(참고) ===
+        String businessPeriodType,      // bizPrdSeCd 라벨
+        String businessBeginYmd,        // bizPrdBgngYmd(YYYY-MM-DD)
+        String businessEndYmd,          // bizPrdEndYmd(YYYY-MM-DD)
+        String businessEtc,             // bizPrdEtcCn
+
+        // === 지역/기타 ===
+        List<String> zipCodes,          // zipCd (콤마 분리)
+        Integer viewCount,              // inqCnt
+        String firstRegisteredAt,       // frstRegDt
+        String lastModifiedAt           // lastMdfcnDt
 ) {}

--- a/src/main/java/com/youthjob/api/youthpolicy/service/CodeDict.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/service/CodeDict.java
@@ -1,0 +1,84 @@
+package com.youthjob.api.youthpolicy.service;
+
+import java.util.*;
+
+final class CodeDict {
+    private CodeDict(){}
+
+    static final Map<String,String> PVSN_INST_GROUP = Map.of(
+            "0054001","중앙부처", "0054002","지자체"
+    );
+
+    static final Map<String,String> PVSN_METHOD = Map.ofEntries(
+            Map.entry("0042001","인프라 구축"), Map.entry("0042002","프로그램"),
+            Map.entry("0042003","직접대출"),   Map.entry("0042004","공공기관"),
+            Map.entry("0042005","계약(위탁운영)"), Map.entry("0042006","보조금"),
+            Map.entry("0042007","대출보증"),   Map.entry("0042008","공적보험"),
+            Map.entry("0042009","조세지출"),   Map.entry("0042010","바우처"),
+            Map.entry("0042011","정보제공"),   Map.entry("0042012","경제적 규제"),
+            Map.entry("0042013","기타")
+    );
+
+    static final Map<String,String> APPLY_PERIOD = Map.of(
+            "0057001","특정기간","0057002","상시","0057003","마감"
+    );
+
+    static final Map<String,String> BIZ_PERIOD = Map.of(
+            "0056001","특정기간","0056002","기타"
+    );
+
+    static final Map<String,String> MARITAL = Map.of(
+            "0055001","기혼","0055002","미혼","0055003","제한없음"
+    );
+
+    static final Map<String,String> INCOME = Map.of(
+            "0043001","무관","0043002","연소득","0043003","기타"
+    );
+
+    static final Map<String,String> MAJOR = Map.ofEntries(
+            Map.entry("0011001","인문계열"), Map.entry("0011002","사회계열"),
+            Map.entry("0011003","상경계열"), Map.entry("0011004","이학계열"),
+            Map.entry("0011005","공학계열"), Map.entry("0011006","예체능계열"),
+            Map.entry("0011007","농산업계열"), Map.entry("0011008","기타"),
+            Map.entry("0011009","제한없음")
+    );
+
+    static final Map<String,String> JOB = Map.ofEntries(
+            Map.entry("0013001","재직자"), Map.entry("0013002","자영업자"),
+            Map.entry("0013003","미취업자"), Map.entry("0013004","프리랜서"),
+            Map.entry("0013005","일용근로자"), Map.entry("0013006","(예비)창업자"),
+            Map.entry("0013007","단기근로자"), Map.entry("0013008","영농종사자"),
+            Map.entry("0013009","기타"),     Map.entry("0013010","제한없음")
+    );
+
+    static final Map<String,String> SCHOOL = Map.ofEntries(
+            Map.entry("0049001","고졸 미만"), Map.entry("0049002","고교 재학"),
+            Map.entry("0049003","고졸 예정"), Map.entry("0049004","고교 졸업"),
+            Map.entry("0049005","대학 재학"), Map.entry("0049006","대졸 예정"),
+            Map.entry("0049007","대학 졸업"), Map.entry("0049008","석·박사"),
+            Map.entry("0049009","기타"),     Map.entry("0049010","제한없음")
+    );
+
+    static final Map<String,String> SBIZ = Map.ofEntries(
+            Map.entry("0014001","중소기업"), Map.entry("0014002","여성"),
+            Map.entry("0014003","기초생활수급자"), Map.entry("0014004","한부모가정"),
+            Map.entry("0014005","장애인"), Map.entry("0014006","농업인"),
+            Map.entry("0014007","군인"), Map.entry("0014008","지역인재"),
+            Map.entry("0014009","기타"), Map.entry("0014010","제한없음")
+    );
+
+    static String label(Map<String,String> dict, String code){
+        if (code==null || code.isBlank()) return null;
+        return dict.getOrDefault(code.trim(), code.trim());
+    }
+
+    static java.util.List<String> decodeCsv(Map<String,String> dict, String csv){
+        if (csv==null || csv.isBlank()) return java.util.List.of();
+        String[] parts = csv.split("\\s*,\\s*");
+        java.util.List<String> out = new java.util.ArrayList<>();
+        for (String p: parts) {
+            if (!p.isBlank()) out.add(label(dict, p));
+        }
+        return out;
+    }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/service/YouthPolicyMapper.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/service/YouthPolicyMapper.java
@@ -1,0 +1,113 @@
+package com.youthjob.api.youthpolicy.service;
+
+import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto.Policy;
+import com.youthjob.api.youthpolicy.dto.YouthPolicyDetailDto;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+public final class YouthPolicyMapper {
+
+    private static final DateTimeFormatter API_YMD = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final DateTimeFormatter OUT_YMD = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    private YouthPolicyMapper(){}
+
+    public static YouthPolicyDetailDto toDetail(Policy p){
+        return YouthPolicyDetailDto.builder()
+                // 기본
+                .plcyNo(p.getPlcyNo())
+                .plcyNm(nz(p.getPlcyNm()))
+                .summary(nz(p.getPlcyExplnCn()))
+                .keywords(splitCsv(nz(p.getPlcyKywdNm())))
+                .categoryL(nz(p.getLclsfNm()))
+                .categoryM(nz(p.getMclsfNm()))
+                // 신청/기간/방법
+                .applyPeriodType(CodeDict.label(CodeDict.APPLY_PERIOD, p.getAplyPrdSeCd()))
+                .applyPeriod(normalizeAplyYmd(p.getAplyYmd()))
+                .applyUrl(nz(p.getAplyUrlAddr()))
+                .applyMethod(nz(p.getPlcyAplyMthdCn()))
+                // 지원내용/선착순/규모
+                .supportContent(nz(p.getPlcySprtCn()))
+                .firstCome("Y".equalsIgnoreCase(nz(p.getSprtArvlSeqYn())))
+                .supportScaleLimited("Y".equalsIgnoreCase(nz(p.getSprtSclLmtYn())))
+                .supportCount(parseIntSafe(p.getSprtSclCnt()))
+                // 자격요건
+                .ageMin(parseIntSafe(p.getSprtTrgtMinAge()))
+                .ageMax(parseIntSafe(p.getSprtTrgtMaxAge()))
+                .ageLimited("Y".equalsIgnoreCase(nz(p.getSprtTrgtAgeLmtYn())))
+                .maritalStatus(CodeDict.label(CodeDict.MARITAL, p.getMrgSttsCd()))
+                .incomeConditionType(CodeDict.label(CodeDict.INCOME, p.getEarnCndSeCd()))
+                .incomeMin(nz(p.getEarnMinAmt()))
+                .incomeMax(nz(p.getEarnMaxAmt()))
+                .incomeEtc(nz(p.getEarnEtcCn()))
+                .jobRequirements(CodeDict.decodeCsv(CodeDict.JOB, p.getJobCd()))
+                .majorRequirement(CodeDict.label(CodeDict.MAJOR, p.getPlcyMajorCd()))
+                .schoolRequirements(CodeDict.decodeCsv(CodeDict.SCHOOL, p.getSchoolCd()))
+                .specialRequirements(CodeDict.decodeCsv(CodeDict.SBIZ, p.getSbizCd()))
+                .additionalQualification(nz(p.getAddAplyQlfcCndCn()))
+                .participantTarget(nz(p.getPtcpPrpTrgtCn()))
+                // 심사/제출/비고
+                .screeningMethod(nz(p.getSrngMthdCn()))
+                .requiredDocs(nz(p.getSbmsnDcmntCn()))
+                .etcNotes(nz(p.getEtcMttrCn()))
+                .refUrls(refUrls(p.getRefUrlAddr1(), p.getRefUrlAddr2()))
+                // 기관/담당
+                .providerGroup(CodeDict.label(CodeDict.PVSN_INST_GROUP, p.getPvsnInstGroupCd()))
+                .provisionMethod(CodeDict.label(CodeDict.PVSN_METHOD, p.getPlcyPvsnMthdCd()))
+                .supervisorName(nz(p.getSprvsnInstCdNm()))
+                .operatorName(nz(p.getOperInstCdNm()))
+                .supervisorContactName(nz(p.getSprvsnInstPicNm()))
+                .operatorContactName(nz(p.getOperInstPicNm()))
+                // 사업기간
+                .businessPeriodType(CodeDict.label(CodeDict.BIZ_PERIOD, p.getBizPrdSeCd()))
+                .businessBeginYmd(formatYmd(p.getBizPrdBgngYmd()))
+                .businessEndYmd(formatYmd(p.getBizPrdEndYmd()))
+                .businessEtc(nz(p.getBizPrdEtcCn()))
+                // 지역/기타
+                .zipCodes(splitCsv(nz(p.getZipCd())))
+                .viewCount(parseIntSafe(p.getInqCnt()))
+                .firstRegisteredAt(nz(p.getFrstRegDt()))
+                .lastModifiedAt(nz(p.getLastMdfcnDt()))
+                .build();
+    }
+
+    // ===== helpers =====
+    private static String nz(String s){ return (s==null || s.isBlank()) ? "" : s.trim(); }
+
+    private static List<String> splitCsv(String csv){
+        if (csv.isEmpty()) return List.of();
+        String[] parts = csv.split("\\s*,\\s*");
+        List<String> out = new ArrayList<>();
+        for (String p: parts) if (!p.isBlank()) out.add(p);
+        return out;
+    }
+
+    private static String formatYmd(String ymd){
+        String v = nz(ymd).replaceAll("\\s+", "");
+        if (v.length()!=8) return v.isEmpty() ? null : v;
+        try { return LocalDate.parse(v, API_YMD).format(OUT_YMD); }
+        catch(Exception e){ return v; }
+    }
+
+    private static String normalizeAplyYmd(String raw){
+        // "20250430 ~ 20250627" / "20250805 ~ 20250822\\N20250301 ~ 20251231"
+        String v = nz(raw);
+        if (v.isEmpty()) return null;
+        return v.replace("\\N", "\n");
+    }
+
+    private static Integer parseIntSafe(String s){
+        String v = nz(s);
+        if (v.isEmpty()) return null;
+        try { return Integer.parseInt(v); } catch(Exception e){ return null; }
+    }
+
+    private static List<String> refUrls(String u1, String u2){
+        List<String> out = new ArrayList<>();
+        if (!nz(u1).isEmpty()) out.add(u1.trim());
+        if (!nz(u2).isEmpty()) out.add(u2.trim());
+        return out;
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 청년정책 **상세보기 DTO 개선**
  - 신청 판단 기준으로 필드 재구성(요약/기간/방법/지원내용/자격/서류/기관정보 등)
  - 날짜(YYYYMMDD→YYYY-MM-DD), Y/N→Boolean, 콤마 문자열→리스트 등 **표준화**
- **코드 → 라벨 변환 도입**
  - `pvsnInstGroupCd, plcyPvsnMthdCd, aplyPrdSeCd, bizPrdSeCd, mrgSttsCd, earnCndSeCd, plcyMajorCd, jobCd, schoolCd, sbizCd`를 사람이 읽는 한글 라벨로 매핑
  - `CodeDict` 추가(사전), `YouthPolicyMapper` 추가(Policy→DTO 변환)
- **컨트롤러(detail) 적용**
  - `GET /api/v1/youth-policies/{plcyNo}`에서 `YouthPolicyMapper.toDetail(...)` 사용하도록 변경

## ➕ 이슈 링크
* Closes #36

## 테스트 방법(POSTMAN)
- GET "/api/v1/youth-policies?plcyKywdNm=보조금&pageNum=1&pageSize=10" : 검색 필터 확인
- GET "/api/v1/youth-policies/{plcyNo}" : 정책 상세 조회
- GET "/api/v1/youth-policies/saved" : 관심 정책 목록 조회
- POST "/api/v1/youth-policies/saved" : 관심 정책 저장
- DELETE "/api/v1/youth-policies/saved/{id}" : 관심 정책 삭제
- POST "/api/v1/youth-policies/saved/toggle" : 관심 정책 토글

## 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)
- [x] 검색 필터 및 관심 정책 기능 로컬 수동 테스트 완료(POSTMAN)

## 📸 스크린샷(선택)
<img width="1371" height="767" alt="image" src="https://github.com/user-attachments/assets/207032fe-a520-4128-bb18-dccbd65675ef" />

