### PR TITLE
[FEAT] 청년지원정책 API DB 적재 구현(#39)

### DIFF
--- a/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyController.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyController.java
@@ -1,16 +1,13 @@
 package com.youthjob.api.youthpolicy.controller;
 
-import com.youthjob.api.youthpolicy.client.YouthPolicyClient;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyApiRequestDto;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyDetailDto;
-import com.youthjob.api.youthpolicy.service.YouthPolicyMapper;
 import com.youthjob.api.youthpolicy.service.YouthPolicyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,24 +15,23 @@ import org.springframework.web.server.ResponseStatusException;
 public class YouthPolicyController {
 
     private final YouthPolicyService service;
-    private final YouthPolicyClient client;
 
-    /** 검색 + 후처리 필터 -> 예시 : /api/v1/youth-policies?plcyKywdNm=보조금&pageNum=1&pageSize=10 */
-    @GetMapping
-    public YouthPolicyApiResponseDto list(@Valid @ModelAttribute YouthPolicyApiRequestDto req) {
-        return service.searchWithFilter(req);
+    /** DB 적재(초기/갱신) - 외부 API 전체 수집해서 DB에 upsert */
+    @PostMapping("/db")
+    public ResponseEntity<String> ingest(@RequestParam(defaultValue = "true") boolean full) {
+        long count = service.ingestAll(full);
+        return ResponseEntity.ok("성공!, 총 " + count + "개의 청년정책 API 연동이 완료되었습니다.");
     }
 
-    /** 상세: /api/v1/youth-policies/{plcyNo} */
+    /** 검색: DB 기반 (기존 외부 API 호출 아님) */
+    @GetMapping
+    public YouthPolicyApiResponseDto list(@Valid @ModelAttribute YouthPolicyApiRequestDto req) {
+        return service.searchFromDb(req);
+    }
+
+    /** 상세: DB 기반 */
     @GetMapping("/{plcyNo}")
     public YouthPolicyDetailDto detail(@PathVariable String plcyNo) {
-        var resp = client.findByPlcyNo(plcyNo);
-        if (resp == null || resp.getResult() == null ||
-                resp.getResult().getYouthPolicyList() == null ||
-                resp.getResult().getYouthPolicyList().isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "정책을 찾을 수 없습니다: " + plcyNo);
-        }
-        var p = resp.getResult().getYouthPolicyList().get(0);
-        return YouthPolicyMapper.toDetail(p);
+        return service.detailFromDb(plcyNo);
     }
 }

--- a/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyFavoriteController.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/controller/YouthPolicyFavoriteController.java
@@ -17,13 +17,13 @@ public class YouthPolicyFavoriteController {
 
     private final YouthPolicyFavoriteService service;
 
-    /** 내 관심 정책 목록 */
+    /** 내 관심 정책 목록 (DB 스냅샷 기준) */
     @GetMapping("/saved")
     public ResponseEntity<List<SavedPolicyDto>> listSaved() {
         return ResponseEntity.ok(service.listSaved());
     }
 
-    /** 관심 저장 (스냅샷 없으면 서버가 외부 API로 채움) */
+    /** 관심 저장: DB의 youth_policy에서 plcyNo로 조회 후 스냅샷 저장 */
     @PostMapping("/saved")
     public ResponseEntity<SavedPolicyDto> save(@RequestBody @Valid SavePolicyRequest req) {
         return ResponseEntity.ok(service.save(req));

--- a/src/main/java/com/youthjob/api/youthpolicy/domain/YouthPolicy.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/domain/YouthPolicy.java
@@ -1,0 +1,142 @@
+package com.youthjob.api.youthpolicy.domain;
+
+import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto.Policy;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "youth_policy",
+        indexes = {
+                @Index(name = "idx_youth_policy_plcyno", columnList = "plcy_no", unique = true),
+                @Index(name = "idx_youth_policy_plcynm", columnList = "plcy_nm"),
+                @Index(name = "idx_youth_policy_zipcd", columnList = "zip_cd"),
+                @Index(name = "idx_youth_policy_lclsf", columnList = "lclsf_nm"),
+                @Index(name = "idx_youth_policy_mclsf", columnList = "mclsf_nm")
+        }
+)
+@EqualsAndHashCode(of = "plcyNo")
+public class YouthPolicy {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "plcy_no", nullable = false, length = 40, unique = true)
+    private String plcyNo;
+
+    @Column(name = "plcy_nm", length = 300) private String plcyNm;
+    @Column(name = "plcy_kywd_nm", length = 500) private String plcyKywdNm;
+
+    @Lob @Column(name = "plcy_expln_cn", columnDefinition = "LONGTEXT") private String plcyExplnCn;
+
+    @Column(name = "lclsf_nm", length = 50) private String lclsfNm;
+    @Column(name = "mclsf_nm", length = 50) private String mclsfNm;
+
+    @Lob @Column(name = "plcy_sprt_cn", columnDefinition = "LONGTEXT") private String plcySprtCn;
+    @Column(name = "sprt_arvl_seq_yn", length = 1) private String sprtArvlSeqYn;
+    @Column(name = "sprt_scl_lmt_yn", length = 1) private String sprtSclLmtYn;
+    @Column(name = "sprt_scl_cnt", length = 20) private String sprtSclCnt;
+
+    @Column(name = "aply_prd_se_cd", length = 20) private String aplyPrdSeCd;
+    @Column(name = "aply_ymd", length = 500) private String aplyYmd;
+    @Column(name = "aply_url_addr", length = 1000) private String aplyUrlAddr;
+    @Lob @Column(name = "plcy_aply_mthd_cn", columnDefinition = "LONGTEXT") private String plcyAplyMthdCn;
+
+    @Column(name = "sprvsn_inst_cd_nm", length = 200) private String sprvsnInstCdNm;
+    @Column(name = "oper_inst_cd_nm", length = 200) private String operInstCdNm;
+
+    // 자격요건 요약
+    @Column(name = "sprt_trgt_min_age", length = 5) private String sprtTrgtMinAge;
+    @Column(name = "sprt_trgt_max_age", length = 5) private String sprtTrgtMaxAge;
+    @Column(name = "sprt_trgt_age_lmt_yn", length = 1) private String sprtTrgtAgeLmtYn;
+    @Column(name = "mrg_stts_cd", length = 20) private String mrgSttsCd;
+    @Column(name = "earn_cnd_se_cd", length = 20) private String earnCndSeCd;
+    @Column(name = "earn_min_amt", length = 30) private String earnMinAmt;
+    @Column(name = "earn_max_amt", length = 30) private String earnMaxAmt;
+    @Lob @Column(name = "earn_etc_cn", columnDefinition = "LONGTEXT") private String earnEtcCn;
+    @Column(name = "job_cd", length = 500) private String jobCd;
+    @Lob @Column(name = "plcy_major_cd", columnDefinition = "LONGTEXT") private String plcyMajorCd;
+    @Column(name = "school_cd", length = 500) private String schoolCd;
+    @Column(name = "sbiz_cd", length = 500) private String sbizCd;
+    @Lob @Column(name = "add_aply_qlfc_cnd_cn", columnDefinition = "LONGTEXT") private String addAplyQlfcCndCn;
+    @Lob @Column(name = "ptcp_prp_trgt_cn", columnDefinition = "LONGTEXT") private String ptcpPrpTrgtCn;
+
+    // 심사/제출/기타
+    @Lob @Column(name = "srng_mthd_cn", columnDefinition = "LONGTEXT") private String srngMthdCn;
+    @Lob @Column(name = "sbmsn_dcmnt_cn", columnDefinition = "LONGTEXT") private String sbmsnDcmntCn;
+    @Lob @Column(name = "etc_mttr_cn", columnDefinition = "LONGTEXT") private String etcMttrCn;
+    @Column(name = "ref_url_addr1", length = 1000) private String refUrlAddr1;
+    @Column(name = "ref_url_addr2", length = 1000) private String refUrlAddr2;
+
+    // 기타
+    @Lob @Column(name = "zip_cd", columnDefinition = "LONGTEXT") private String zipCd;
+    @Column(name = "inq_cnt", length = 20)  private String inqCnt;
+
+    @Column(name = "frst_reg_dt", length = 30) private String frstRegDt;
+    @Column(name = "last_mdfcn_dt", length = 30) private String lastMdfcnDt;
+
+    /** 신규 엔티티 생성 */
+    public static YouthPolicy of(Policy p) {
+        YouthPolicy e = new YouthPolicy();
+        e.plcyNo = nz(p.getPlcyNo());
+        e.apply(p);
+        return e;
+    }
+
+    /** 기존 엔티티 갱신(허용된 경로) */
+    public void apply(Policy p) {
+        this.plcyNm = nz(p.getPlcyNm());
+        this.plcyKywdNm = nz(p.getPlcyKywdNm());
+        this.plcyExplnCn = nz(p.getPlcyExplnCn());
+
+        this.lclsfNm = nz(p.getLclsfNm());
+        this.mclsfNm = nz(p.getMclsfNm());
+
+        this.plcySprtCn = nz(p.getPlcySprtCn());
+        this.sprtArvlSeqYn = nz(p.getSprtArvlSeqYn());
+        this.sprtSclLmtYn = nz(p.getSprtSclLmtYn());
+        this.sprtSclCnt = nz(p.getSprtSclCnt());
+
+        this.aplyPrdSeCd = nz(p.getAplyPrdSeCd());
+        this.aplyYmd = nz(p.getAplyYmd());
+        this.aplyUrlAddr = nz(p.getAplyUrlAddr());
+        this.plcyAplyMthdCn = nz(p.getPlcyAplyMthdCn());
+
+        this.sprvsnInstCdNm = nz(p.getSprvsnInstCdNm());
+        this.operInstCdNm = nz(p.getOperInstCdNm());
+
+        this.sprtTrgtMinAge = nz(p.getSprtTrgtMinAge());
+        this.sprtTrgtMaxAge = nz(p.getSprtTrgtMaxAge());
+        this.sprtTrgtAgeLmtYn = nz(p.getSprtTrgtAgeLmtYn());
+        this.mrgSttsCd = nz(p.getMrgSttsCd());
+        this.earnCndSeCd = nz(p.getEarnCndSeCd());
+        this.earnMinAmt = nz(p.getEarnMinAmt());
+        this.earnMaxAmt = nz(p.getEarnMaxAmt());
+        this.earnEtcCn = nz(p.getEarnEtcCn());
+        this.jobCd = nz(p.getJobCd());
+        this.plcyMajorCd = nz(p.getPlcyMajorCd());
+        this.schoolCd = nz(p.getSchoolCd());
+        this.sbizCd = nz(p.getSbizCd());
+        this.addAplyQlfcCndCn = nz(p.getAddAplyQlfcCndCn());
+        this.ptcpPrpTrgtCn = nz(p.getPtcpPrpTrgtCn());
+
+        this.srngMthdCn = nz(p.getSrngMthdCn());
+        this.sbmsnDcmntCn = nz(p.getSbmsnDcmntCn());
+        this.etcMttrCn = nz(p.getEtcMttrCn());
+        this.refUrlAddr1 = nz(p.getRefUrlAddr1());
+        this.refUrlAddr2 = nz(p.getRefUrlAddr2());
+
+        this.zipCd = nz(p.getZipCd());
+        this.inqCnt = nz(p.getInqCnt());
+
+        this.frstRegDt = nz(p.getFrstRegDt());
+        this.lastMdfcnDt = nz(p.getLastMdfcnDt());
+    }
+
+    private static String nz(String s) { return s == null ? "" : s; }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/repository/SavedPolicyRepository.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/repository/SavedPolicyRepository.java
@@ -15,7 +15,6 @@ public interface SavedPolicyRepository extends JpaRepository<SavedPolicy, Long> 
     Optional<SavedPolicy> findByIdAndUser(Long id, User user);
     Optional<SavedPolicy> findByUserAndPlcyNo(User user, String plcyNo);
 
-    // === 추가: 마이페이지용 ===
     Page<SavedPolicy> findByUser(User user, Pageable pageable);
     long countByUser(User user);
 }

--- a/src/main/java/com/youthjob/api/youthpolicy/repository/YouthPolicyRepository.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/repository/YouthPolicyRepository.java
@@ -1,0 +1,17 @@
+package com.youthjob.api.youthpolicy.repository;
+
+import com.youthjob.api.youthpolicy.domain.YouthPolicy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface YouthPolicyRepository
+        extends JpaRepository<YouthPolicy, Long>, JpaSpecificationExecutor<YouthPolicy> {
+
+    Optional<YouthPolicy> findByPlcyNo(String plcyNo);
+
+    List<YouthPolicy> findAllByPlcyNoIn(Collection<String> plcyNos);
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/service/YouthPolicyFetcherExecutorConfig.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/service/YouthPolicyFetcherExecutorConfig.java
@@ -1,0 +1,19 @@
+package com.youthjob.api.youthpolicy.service;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class YouthPolicyFetcherExecutorConfig {
+    @Bean(name = "youthPolicyFetcherExecutor")
+    public ThreadPoolTaskExecutor youthPolicyFetcherExecutor() {
+        ThreadPoolTaskExecutor ex = new ThreadPoolTaskExecutor();
+        ex.setCorePoolSize(8);
+        ex.setMaxPoolSize(16);
+        ex.setQueueCapacity(1000);
+        ex.setThreadNamePrefix("yp-fetch-");
+        ex.initialize();
+        return ex;
+    }
+}

--- a/src/main/java/com/youthjob/api/youthpolicy/service/YouthPolicyService.java
+++ b/src/main/java/com/youthjob/api/youthpolicy/service/YouthPolicyService.java
@@ -3,192 +3,258 @@ package com.youthjob.api.youthpolicy.service;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.youthjob.api.youthpolicy.client.YouthPolicyClient;
+import com.youthjob.api.youthpolicy.domain.YouthPolicy;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyApiRequestDto;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto;
 import com.youthjob.api.youthpolicy.dto.YouthPolicyApiResponseDto.Policy;
+import com.youthjob.api.youthpolicy.dto.YouthPolicyDetailDto;
+import com.youthjob.api.youthpolicy.repository.YouthPolicyRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.*;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.persistence.criteria.Predicate;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class YouthPolicyService {
 
-    private final YouthPolicyClient client;
+    private final YouthPolicyClient client; // 외부 API 적재시에만 사용
+    private final YouthPolicyRepository repo;
     private final ThreadPoolTaskExecutor youthPolicyFetcherExecutor;
     private final ObjectMapper mapper = new ObjectMapper();
 
-    /**
-     * - 병렬 수집 + 파라미터 기반 캐시 + 서버단 페이징
-     * - 캐시 키: 필터 + pageNum + pageSize
-     * - 외부 API는 끝까지 병렬 수집
-     * - 수집 후 서버단 필터 → (totCount 계산) → 요청한 pageNum/pageSize로 슬라이스
-     */
-    @Cacheable(
-            value = "youthPolicies",
-            key =
-                    "'yp:'"
-                            + " + (#req.plcyKywdNm != null ? #req.plcyKywdNm : '')"
-                            + " + ':' + (#req.plcyNm != null ? #req.plcyNm : '')"
-                            + " + ':' + (#req.plcyExpInCn != null ? #req.plcyExpInCn : '')"
-                            + " + ':' + (#req.zipCd != null ? #req.zipCd : '')"
-                            + " + ':' + (#req.lclsfNm != null ? #req.lclsfNm : '')"
-                            + " + ':' + (#req.mclsfNm != null ? #req.mclsfNm : '')"
-                            + " + ':' + (#req.pageNum != null ? #req.pageNum : 1)"
-                            + " + ':' + (#req.pageSize != null ? #req.pageSize : 10)"
-    )
-
-    public YouthPolicyApiResponseDto searchWithFilter(YouthPolicyApiRequestDto req) {
-        long t0 = System.currentTimeMillis();
-
+    /** 외부 전체 수집 → DB upsert */
+    @Transactional
+    public long ingestAll(boolean full) {
         final int fetchChunk = 500;
-        final int startPage  = (req.getPageNum()  != null && req.getPageNum()  > 0) ? req.getPageNum()  : 1;
-        final int pageSize   = (req.getPageSize() != null && req.getPageSize() > 0) ? req.getPageSize() : 10;
+        int fetchedTotal = 0;
 
-        YouthPolicyApiResponseDto first = client.search(copyForPage(req, startPage, fetchChunk));
-        if (first == null || first.getResult() == null) return first;
+        YouthPolicyApiRequestDto req0 = new YouthPolicyApiRequestDto();
+        req0.setPageNum(1);
+        req0.setPageSize(fetchChunk);
+        YouthPolicyApiResponseDto first = client.search(req0);
+        if (first == null || first.getResult() == null) return 0;
 
-        List<Policy> acc = new ArrayList<>(nullSafe(first.getResult().getYouthPolicyList()));
-        Integer totCount = (first.getResult().getPagging() != null)
+        List<Policy> firstItems = nullSafe(first.getResult().getYouthPolicyList());
+        upsertPolicies(firstItems, full);
+        fetchedTotal += firstItems.size();
+
+        Integer totCount = first.getResult().getPagging() != null
                 ? first.getResult().getPagging().getTotCount()
                 : null;
 
         if (totCount != null) {
-            int totalPages = (int) Math.ceil((double) totCount / Math.max(fetchChunk, 1));
-            if (totalPages > startPage) {
+            int totalPages = (int) Math.ceil((double) totCount / fetchChunk);
+            if (totalPages > 1) {
                 List<CompletableFuture<List<Policy>>> futures = new ArrayList<>();
-                for (int p = startPage + 1; p <= totalPages; p++) {
+                for (int p = 2; p <= totalPages; p++) {
                     final int page = p;
-                    futures.add(CompletableFuture.supplyAsync(() -> {
-                        YouthPolicyApiResponseDto r = client.search(copyForPage(req, page, fetchChunk));
-                        List<Policy> items = (r != null && r.getResult() != null)
-                                ? nullSafe(r.getResult().getYouthPolicyList())
-                                : List.of();
-                        log.debug("[YouthPolicy] fetched page={} chunk={} count={}", page, fetchChunk, items.size());
-                        return items;
-                    }, youthPolicyFetcherExecutor));
+                    futures.add(
+                            CompletableFuture.<List<Policy>>supplyAsync(() -> {
+                                YouthPolicyApiRequestDto r = new YouthPolicyApiRequestDto();
+                                r.setPageNum(page);
+                                r.setPageSize(fetchChunk);
+
+                                YouthPolicyApiResponseDto resp = client.search(r);
+                                List<Policy> items =
+                                        (resp != null && resp.getResult() != null)
+                                                ? nullSafe(resp.getResult().getYouthPolicyList())
+                                                : Collections.<Policy>emptyList();
+
+                                log.debug("[Ingest] fetched page={} size={}", page, items.size());
+                                return items;
+                            }, youthPolicyFetcherExecutor)
+                    );
                 }
                 CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-                for (int i = 0; i < futures.size(); i++) {
-                    try { acc.addAll(futures.get(i).join()); }
-                    catch (Exception e) {
-                        int failPage = startPage + 1 + i;
-                        log.warn("[YouthPolicy] page {} join failed: {}", failPage, e.toString());
-                    }
+                for (CompletableFuture<List<Policy>> f : futures) {
+                    List<Policy> items = f.join();
+                    upsertPolicies(items, full);
+                    fetchedTotal += items.size();
                 }
             }
         } else {
-            int p = startPage + 1, safety = 0;
+            int p = 2, safety = 0;
             while (true) {
-                YouthPolicyApiResponseDto r = client.search(copyForPage(req, p, fetchChunk));
-                List<Policy> items = (r != null && r.getResult() != null)
-                        ? nullSafe(r.getResult().getYouthPolicyList())
-                        : List.of();
+                YouthPolicyApiRequestDto r = new YouthPolicyApiRequestDto();
+                r.setPageNum(p);
+                r.setPageSize(fetchChunk);
+
+                YouthPolicyApiResponseDto resp = client.search(r);
+                List<Policy> items =
+                        (resp != null && resp.getResult() != null)
+                                ? nullSafe(resp.getResult().getYouthPolicyList())
+                                : Collections.<Policy>emptyList();
+
                 if (items.isEmpty()) break;
-                acc.addAll(items);
-                if (items.size() < fetchChunk) break;
-                if (++safety > 5000) { log.warn("[YouthPolicy] safety break at page {}", p); break; }
+                upsertPolicies(items, full);
+                fetchedTotal += items.size();
+                if (++safety > 10000) break;
                 p++;
             }
         }
 
-        List<Policy> filtered = applyServerFilters(acc, req);
+        log.info("[Ingest] Done. fetchedTotal={}", fetchedTotal);
+        return fetchedTotal;
+    }
 
-        int total = filtered.size();
-        int from  = Math.max(0, (startPage - 1) * pageSize);
-        int to    = Math.min(total, from + pageSize);
-        List<Policy> slice = (from < to) ? filtered.subList(from, to) : List.of();
+    /** Upsert: plcyNo 기준 중복 제거 후 있으면 apply(p), 없으면 of(p) */
+    @Transactional
+    protected void upsertPolicies(List<Policy> items, boolean full) {
+        if (items == null || items.isEmpty()) return;
 
-        Map<String, Object> tree   = mapper.convertValue(first, new TypeReference<>() {});
-        Map<String, Object> result = castMap(tree.get("result"));
-        Map<String, Object> pag    = castMap(result.get("pagging"));
+        // 1) 같은 배치 내 plcyNo 중복 제거 (마지막 값으로 덮어쓰기)
+        Map<String, Policy> dedup = new LinkedHashMap<>();
+        for (Policy p : items) {
+            if (p.getPlcyNo() != null && !p.getPlcyNo().isBlank()) {
+                dedup.put(p.getPlcyNo(), p);
+            }
+        }
+        if (dedup.isEmpty()) return;
 
-        result.put("youthPolicyList",
-                mapper.convertValue(slice, new TypeReference<List<Map<String, Object>>>() {}));
-        pag.put("totCount", total);
-        pag.put("pageNum",  startPage);
+        // 2) 기존 엔티티 일괄 조회 → 맵
+        List<YouthPolicy> existing = repo.findAllByPlcyNoIn(dedup.keySet());
+        Map<String, YouthPolicy> map = new HashMap<>(existing.size());
+        for (YouthPolicy e : existing) map.put(e.getPlcyNo(), e);
+
+        // 3) upsert
+        List<YouthPolicy> toSave = new ArrayList<>(dedup.size());
+        for (Map.Entry<String, Policy> e : dedup.entrySet()) {
+            String no = e.getKey();
+            Policy p = e.getValue();
+            YouthPolicy cur = map.get(no);
+            if (cur != null) {
+                cur.apply(p);
+                toSave.add(cur);
+            } else {
+                toSave.add(YouthPolicy.of(p));
+            }
+        }
+
+        repo.saveAll(toSave);
+    }
+
+    private static <T> List<T> nullSafe(List<T> l){
+        return (l != null) ? l : Collections.<T>emptyList();
+    }
+
+    /** DB 기반 검색 (외부 API 호출 없음, 기존 응답 스펙 유지) */
+    @Transactional(readOnly = true)
+    public YouthPolicyApiResponseDto searchFromDb(YouthPolicyApiRequestDto req) {
+        int pageNum  = (req.getPageNum()  != null && req.getPageNum()  > 0) ? req.getPageNum()  : 1;
+        int pageSize = (req.getPageSize() != null && req.getPageSize() > 0) ? req.getPageSize() : 10;
+
+        Pageable pageable = PageRequest.of(pageNum - 1, pageSize, Sort.by(Sort.Direction.DESC, "id"));
+        Specification<YouthPolicy> spec = buildSpec(req);
+
+        Page<YouthPolicy> page = repo.findAll(spec, pageable);
+        List<Policy> list = page.getContent().stream().map(this::toPolicy).toList();
+
+        Map<String, Object> tree = new HashMap<>();
+        Map<String, Object> result = new HashMap<>();
+        Map<String, Object> pag = new HashMap<>();
+
+        tree.put("resultCode", 0);
+        tree.put("resultMessage", "OK");
+        tree.put("result", result);
+        result.put("youthPolicyList", mapper.convertValue(list, new TypeReference<List<Map<String,Object>>>(){}));
+        pag.put("totCount", (int) page.getTotalElements());
+        pag.put("pageNum", pageNum);
         pag.put("pageSize", pageSize);
-
-        log.info("[YouthPolicy] OK filters={}, total={}, page={}/{}, elapsedMs={}ms",
-                filterKeyForLog(req), total, startPage, pageSize, System.currentTimeMillis() - t0);
+        result.put("pagging", pag);
 
         return mapper.convertValue(tree, YouthPolicyApiResponseDto.class);
     }
 
-    // ===== 유틸 =====
-    private static YouthPolicyApiRequestDto copyForPage(YouthPolicyApiRequestDto o, int pageNum, int pageSize) {
-        YouthPolicyApiRequestDto c = new YouthPolicyApiRequestDto();
-        c.setRtnType(o.getRtnType());
-        c.setPageType(o.getPageType());
-        c.setPageNum(pageNum);
-        c.setPageSize(pageSize);
-        c.setPlcyNo(o.getPlcyNo());
-        c.setPlcyKywdNm(o.getPlcyKywdNm());
-        c.setPlcyNm(o.getPlcyNm());
-        c.setPlcyExpInCn(o.getPlcyExpInCn());
-        c.setZipCd(o.getZipCd());
-        c.setLclsfNm(o.getLclsfNm());
-        c.setMclsfNm(o.getMclsfNm());
-        return c;
+    private Specification<YouthPolicy> buildSpec(YouthPolicyApiRequestDto r) {
+        return (root, query, cb) -> {
+            List<Predicate> ps = new ArrayList<>();
+
+            if (notBlank(r.getPlcyKywdNm())) {
+                ps.add(cb.like(root.get("plcyKywdNm"), "%" + r.getPlcyKywdNm().trim() + "%"));
+            }
+            if (notBlank(r.getPlcyNm())) {
+                ps.add(cb.like(root.get("plcyNm"), "%" + r.getPlcyNm().trim() + "%"));
+            }
+            if (notBlank(r.getPlcyExpInCn())) {
+                ps.add(cb.like(root.get("plcyExplnCn"), "%" + r.getPlcyExpInCn().trim() + "%"));
+            }
+            if (notBlank(r.getZipCd())) {
+                ps.add(cb.like(root.get("zipCd"), "%" + r.getZipCd().trim() + "%"));
+            }
+            if (notBlank(r.getLclsfNm())) {
+                ps.add(cb.like(root.get("lclsfNm"), "%" + r.getLclsfNm().trim() + "%"));
+            }
+            if (notBlank(r.getMclsfNm())) {
+                ps.add(cb.like(root.get("mclsfNm"), "%" + r.getMclsfNm().trim() + "%"));
+            }
+            if (notBlank(r.getPlcyNo())) {
+                ps.add(cb.equal(root.get("plcyNo"), r.getPlcyNo().trim()));
+            }
+
+            return cb.and(ps.toArray(new Predicate[0]));
+        };
     }
 
-    private static <T> List<T> nullSafe(List<T> l){ return l != null ? l : List.of(); }
-    private static boolean notBlank(String s){ return s != null && !s.isBlank(); }
-    private static boolean contains(String src, String kw){ return src != null && src.contains(kw); }
-    private static boolean containsAnyToken(String src, String kw){
-        if (src == null || kw == null || kw.isBlank()) return false;
-        return Stream.of(src.split("[,，]")).map(String::trim).anyMatch(t -> t.contains(kw));
+    private boolean notBlank(String s){ return s != null && !s.isBlank(); }
+
+    private Policy toPolicy(YouthPolicy e) {
+        return Policy.builder()
+                .plcyNo(e.getPlcyNo())
+                .plcyNm(e.getPlcyNm())
+                .plcyKywdNm(e.getPlcyKywdNm())
+                .plcyExplnCn(e.getPlcyExplnCn())
+                .lclsfNm(e.getLclsfNm())
+                .mclsfNm(e.getMclsfNm())
+                .plcySprtCn(e.getPlcySprtCn())
+                .sprtArvlSeqYn(e.getSprtArvlSeqYn())
+                .sprtSclLmtYn(e.getSprtSclLmtYn())
+                .sprtSclCnt(e.getSprtSclCnt())
+                .aplyPrdSeCd(e.getAplyPrdSeCd())
+                .aplyYmd(e.getAplyYmd())
+                .aplyUrlAddr(e.getAplyUrlAddr())
+                .plcyAplyMthdCn(e.getPlcyAplyMthdCn())
+                .sprvsnInstCdNm(e.getSprvsnInstCdNm())
+                .operInstCdNm(e.getOperInstCdNm())
+                .sprtTrgtMinAge(e.getSprtTrgtMinAge())
+                .sprtTrgtMaxAge(e.getSprtTrgtMaxAge())
+                .sprtTrgtAgeLmtYn(e.getSprtTrgtAgeLmtYn())
+                .mrgSttsCd(e.getMrgSttsCd())
+                .earnCndSeCd(e.getEarnCndSeCd())
+                .earnMinAmt(e.getEarnMinAmt())
+                .earnMaxAmt(e.getEarnMaxAmt())
+                .earnEtcCn(e.getEarnEtcCn())
+                .jobCd(e.getJobCd())
+                .plcyMajorCd(e.getPlcyMajorCd())
+                .schoolCd(e.getSchoolCd())
+                .sbizCd(e.getSbizCd())
+                .addAplyQlfcCndCn(e.getAddAplyQlfcCndCn())
+                .ptcpPrpTrgtCn(e.getPtcpPrpTrgtCn())
+                .srngMthdCn(e.getSrngMthdCn())
+                .sbmsnDcmntCn(e.getSbmsnDcmntCn())
+                .etcMttrCn(e.getEtcMttrCn())
+                .refUrlAddr1(e.getRefUrlAddr1())
+                .refUrlAddr2(e.getRefUrlAddr2())
+                .zipCd(e.getZipCd())
+                .inqCnt(e.getInqCnt())
+                .frstRegDt(e.getFrstRegDt())
+                .lastMdfcnDt(e.getLastMdfcnDt())
+                .build();
     }
 
-    @SuppressWarnings("unchecked")
-    private static Map<String,Object> castMap(Object o){
-        return (o instanceof Map) ? (Map<String, Object>) o : new HashMap<>();
-    }
-
-    private static String filterKeyForLog(YouthPolicyApiRequestDto r) {
-        return String.join("|",
-                Optional.ofNullable(r.getPlcyKywdNm()).orElse(""),
-                Optional.ofNullable(r.getPlcyNm()).orElse(""),
-                Optional.ofNullable(r.getPlcyExpInCn()).orElse(""),
-                Optional.ofNullable(r.getZipCd()).orElse(""),
-                Optional.ofNullable(r.getLclsfNm()).orElse(""),
-                Optional.ofNullable(r.getMclsfNm()).orElse(""));
-    }
-
-    /** 서버단 필터 */
-    private List<Policy> applyServerFilters(List<Policy> src, YouthPolicyApiRequestDto req) {
-        List<Policy> list = new ArrayList<>(src);
-        if (notBlank(req.getPlcyKywdNm())) {
-            String kw = req.getPlcyKywdNm().trim();
-            list = list.stream().filter(p -> containsAnyToken(p.getPlcyKywdNm(), kw)).toList();
-        }
-        if (notBlank(req.getPlcyNm())) {
-            String kw = req.getPlcyNm().trim();
-            list = list.stream().filter(p -> contains(p.getPlcyNm(), kw)).toList();
-        }
-        if (notBlank(req.getPlcyExpInCn())) {
-            String kw = req.getPlcyExpInCn().trim();
-            list = list.stream().filter(p -> contains(p.getPlcyExplnCn(), kw)).toList();
-        }
-        if (notBlank(req.getZipCd())) {
-            String kw = req.getZipCd().trim();
-            list = list.stream().filter(p -> contains(p.getZipCd(), kw)).toList();
-        }
-        if (notBlank(req.getLclsfNm())) {
-            String kw = req.getLclsfNm().trim();
-            list = list.stream().filter(p -> contains(p.getLclsfNm(), kw)).toList();
-        }
-        if (notBlank(req.getMclsfNm())) {
-            String kw = req.getMclsfNm().trim();
-            list = list.stream().filter(p -> contains(p.getMclsfNm(), kw)).toList();
-        }
-        return list;
+    @Transactional(readOnly = true)
+    public YouthPolicyDetailDto detailFromDb(String plcyNo) {
+        YouthPolicy e = repo.findByPlcyNo(plcyNo)
+                .orElseThrow(() -> new IllegalArgumentException("정책을 찾을 수 없습니다: " + plcyNo));
+        Policy p = toPolicy(e);
+        return YouthPolicyMapper.toDetail(p);
     }
 }

--- a/src/main/java/com/youthjob/common/config/CacheConfig.java
+++ b/src/main/java/com/youthjob/common/config/CacheConfig.java
@@ -6,7 +6,6 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.TimeUnit;
 
@@ -19,20 +18,9 @@ public class CacheConfig {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager("youthPolicies");
         cacheManager.setCaffeine(
                 Caffeine.newBuilder()
-                        .expireAfterWrite(30, TimeUnit.MINUTES) // 30분 캐싱
-                        .maximumSize(200)                       // 최대 캐시 항목 수
+                        .expireAfterWrite(30, TimeUnit.MINUTES)
+                        .maximumSize(200)
         );
         return cacheManager;
-    }
-
-    @Bean
-    public ThreadPoolTaskExecutor youthPolicyFetcherExecutor() {
-        ThreadPoolTaskExecutor ex = new ThreadPoolTaskExecutor();
-        ex.setCorePoolSize(6);   // 동시 요청 6개까지
-        ex.setMaxPoolSize(12);
-        ex.setQueueCapacity(0);  // 큐 적체 방지
-        ex.setThreadNamePrefix("yp-fetch-");
-        ex.initialize();
-        return ex;
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 청년정책 **전수 적재 & DB 기반 조회**로 구조 전환
  - `POST /api/v1/youth-policies/db?full=true` : 외부 오픈API 병렬 수집 → DB upsert
  - 검색/상세 API는 이제 **DB에서 바로 조회** (외부 API 재호출 없음)
- 스키마/엔티티 정비
  - `YouthPolicy` 엔티티/레포지토리 추가, JPA `Specification` 기반 검색
  - 장문 필드 `LONGTEXT` 확대 (`plcy_sprt_cn`, `plcy_expln_cn`, `plcy_aply_mthd_cn`, `earn_etc_cn`, `add_aply_qlfc_cnd_cn`, `ptcp_prp_trgt_cn`, `srng_mthd_cn`, `sbmsn_dcmnt_cn`, `etc_mttr_cn`, `zip_cd`)
- 관심 정책(즐겨찾기) 로직 정비
  - 저장 시 DB 스냅샷 활용(외부 API 보조 호출 불필요)
  - 목록/저장/삭제/토글 API 기존 스펙 유지
- 성능/안정성
  - 병렬 수집 `ThreadPoolTaskExecutor` 분리 (`YouthPolicyFetcherExecutorConfig`)
  - 대용량 적재 시 `saveAll` 실패 대비 one-by-one 리트라이 & 문제 레코드 로깅 가드
  
## ➕ 이슈 링크
* Closes #39

## 테스트 방법(POSTMAN)
- POST /api/v1/youth-policies/db?full=true : API -> DB 적재
- GET /api/v1/youth-policies?pageNum=1&pageSize=10&plcyKywdNm=보조금 : DB에서 정책 검색 1(검색 필터)
- GET /api/v1/youth-policies?plcyNm=청년&lclsfNm=주거 : 검색 예시 2
- GET "/api/v1/youth-policies/{plcyNo}" : 정책 상세 조회
- GET "/api/v1/youth-policies/saved" : 관심 정책 목록 조회
- POST "/api/v1/youth-policies/saved" : 관심 정책 저장
- DELETE "/api/v1/youth-policies/saved/{id}" : 관심 정책 삭제
- POST "/api/v1/youth-policies/saved/toggle" : 관심 정책 토글

## 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)
- [x] 검색 필터 및 관심 정책 기능 로컬 수동 테스트 완료(POSTMAN)
- [ ] DB 기존 스키마 수정

## 📸 스크린샷(선택)
<img width="1369" height="474" alt="image" src="https://github.com/user-attachments/assets/62347d4b-b860-4da7-b5e6-b74d073a6108" />

