### PR TITLE
[FIX] 헬스체크 URL 인증 허용

### DIFF
--- a/src/main/java/com/youthjob/api/auth/config/SecurityConfig.java
+++ b/src/main/java/com/youthjob/api/auth/config/SecurityConfig.java
@@ -57,6 +57,8 @@ public class SecurityConfig {
                                 "/api/health",
                                 "/api/chat/**",
                                 "/internal/**",
+                                "/actuator/health",
+                                "/actuator/health/**",
                                 "/actuator/prometheus"
                                 ).permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 🔎 작업 내용
*  헬스체크 URL 인증 허용
## ➕ 이슈 링크
* #51 

